### PR TITLE
Add p2p Hack Club website

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -340,6 +340,10 @@ nioflb:
 - ttl: 1
   type: A
   value: 190.106.131.222
+p2p:
+  ttl: 1
+  type: CNAME
+  value: p2phackclub.thatrobot.dev.
 pic._domainkey.mail:
   ttl: 1
   type: TXT


### PR DESCRIPTION
Adds a CNAME that points to p2phackclub.thatrobot.dev, where our website is being deployed