### PR TITLE
Update mc.hackclub.com to the vanilla server

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -415,7 +415,7 @@ maxday:
 mc:
 - ttl: 1
   type: A
-  value: 173.208.140.123
+  value: 173.208.140.125
 mcneil:
 - ttl: 1
   type: A


### PR DESCRIPTION
The modded server doesn't exist anymore so there's no reason to keep this IP here - now it just goes to the vanilla server IP