### PR TITLE
Remove Pepix Records

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -397,10 +397,6 @@ mailo._domainkey.testing.mail:
   ttl: 1
   type: TXT
   value: k=rsa
-manager.us-central1.pexip:
-  ttl: 1
-  type: A
-  value: 35.209.100.178
 markdown:
 - ttl: 1
   type: CNAME
@@ -456,10 +452,6 @@ nioflb:
 - ttl: 1
   type: A
   value: 190.106.131.222
-node1.us-central1.pexip:
-  ttl: 1
-  type: A
-  value: 35.208.181.69
 p2p:
   ttl: 1
   type: CNAME
@@ -472,18 +464,6 @@ packages:
   ttl: 1
   type: CNAME
   value: secret-zebra-lydr194iy8x0x4n4rmzcii3r.herokudns.com.
-pepix-manager:
-  ttl: 1
-  type: A
-  value: 35.209.100.178
-pexip-manager:
-  ttl: 1
-  type: A
-  value: 35.209.100.178
-pexip-manager-hackclub:
-  ttl: 1
-  type: A
-  value: 35.209.100.178
 pic._domainkey.mail:
   ttl: 1
   type: TXT


### PR DESCRIPTION
These no longer point to Hack Club-owned IPs.