### PR TITLE
Add Summer of Making Closed Site

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -689,6 +689,10 @@ smus:
 - ttl: 1
   type: CNAME
   value: smushackclub.github.io.
+som-hardware-closed:
+- ttl: 1
+  type: CNAME
+  value: nifty-stonebraker-d6d007.netlify.app.
 spp:
 - ttl: 1
   type: CNAME


### PR DESCRIPTION
Just a site that says hardware grants are closed 

I'm thinking https://hack.af/hwp-apply should redirect here