### PR TITLE
Add "is steggy a" site from recent ship.

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -496,6 +496,10 @@ indiablog:
   ttl: 1
   type: CNAME
   value: cname.vercel-dns.com.
+issteggya:
+- ttl: 1
+  type: CNAME
+  value: issteggya.hkatzdev.repl.co..
 jg2ygmrfby4vhxve3cozh4yz3xc2ul5y._domainkey:
 - ttl: 1
   type: CNAME


### PR DESCRIPTION
Due to a DoS freenom took down the domain. While the domain hack is no longer possible, we would still like to keep the website up CC @rfblock.