### PR TITLE
Try to get haas.hackclub.com back online

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -33,6 +33,10 @@
   ttl: 1
   type: CNAME
   value: proxy.servers.hackclub.com.
+"*.haas":
+  ttl: 1
+  type: A
+  value: 45.55.45.5
 "*.hosted":
   ttl: 1
   type: A
@@ -589,6 +593,10 @@ gwas:
    ttl: 1
    type: CNAME
    value: competent-yonath-7f9d16.netlify.app.
+haas:
+  ttl: 1
+  type: A
+  value: 45.55.45.5
 hackathons:
   ttl: 1
   type: CNAME


### PR DESCRIPTION
Reverts hackclub/dns#480. Attempting to get this back online.