### PR TITLE
chore: add hackinux domain for apac challenge

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -655,6 +655,10 @@ hackstore:
   ttl: 1
   type: CNAME
   value: cname.vercel-dns.com.
+hackinux:
+  ttl: 1
+  type: CNAME
+  value: cname.vercel-dns.com.
 hillsdale:
 - ttl: 1
   type: CNAME


### PR DESCRIPTION
this is a domain for the Hackinux challenge that HC APAC is organizing.