### PR TITLE
Transfer Domain for Ronald Reagan High School

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -970,7 +970,7 @@ riverbend:
 rr:
 - ttl: 1
   type: CNAME
-  value: sarthak-dayal.github.io.
+  value: rr-cs-club.github.io.
 s1._domainkey:
   ttl: 1
   type: CNAME


### PR DESCRIPTION
Transfer Domain for Ronald Reagan High School to Organization account and update in Hack Club DNS