### PR TITLE
add: uet and byte club sub-domains

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -393,6 +393,10 @@ cecclphs:
 - ttl: 3600
   type: TXT
   value: google-site-verification=_c3oOWsKBUxlmaanXeqC1tBTLNZGflwsEMQQiuP-EUM
+cgc:
+- ttl: 1
+  type: CNAME
+  value: cname.vercel-dns.com.
 changelog.bank:
   ttl: 1
   type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -747,6 +747,10 @@ kiit:
 - ttl: 1
   type: CNAME
   value: kiithackclub.github.io.
+kjcmt:
+  ttl: 1
+  type: CNAME
+  value: cname.vercel-dns.com.
 kmea:
 - ttl: 1
   type: A

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -360,6 +360,10 @@ bucky:
 - ttl: 1
   type: CNAME
   value: lit-anenome-0a8n6ev3vwpusdyktkunqnea.herokudns.com.
+byteclub:
+- ttl: 1
+  type: CNAME
+  value: cname.vercel-dns.com.
 calendar:
   ttl: 1
   type: CNAME
@@ -1212,6 +1216,10 @@ turner:
 - ttl: 1
   type: A
   value: 173.172.147.235
+uet:
+- ttl: 1
+  type: CNAME
+  value: cname.vercel-dns.com.
 university:
 - ttl: 1
   type: CNAME


### PR DESCRIPTION
The following sub-domains have been requested by two Hack Clubs in the APAC region.

This pull request adds them, following are the requested subdomains
1. uet
2. byteclub