### PR TITLE
re: `byte.hackclub.com` because the last...

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -367,7 +367,7 @@ bulc:
 byte:
   - ttl: 1
     type: CNAME
-    value: unsolicitedsite.co.in/byteclub/.
+    value: byteclub.netlify.app.
 byteclub:
 - ttl: 1
   type: CNAME


### PR DESCRIPTION
re: `byte.hackclub.com` because the last one wasn't netlify connected so it didn't work.