### PR TITLE
Update hackclub.com.yaml for saimaa.hackclub.com's new github org

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1034,7 +1034,7 @@ sa:
 saimaa:
   ttl: 1
   type: CNAME
-  value: hacksaimaa.github.io.
+  value: hcksm.github.io.
 saleh:
   ttl: 1
   type: CNAME


### PR DESCRIPTION
This subdomain was originally pointed at our primary org @HackSaimaa, but the repo was moved to @hcksm so thats why this update is necessary.