### PR TITLE
Add `wwww.dinosaurbbq.org`

### DIFF
--- a/dinosaurbbq.org.yaml
+++ b/dinosaurbbq.org.yaml
@@ -2,3 +2,7 @@
 www:
   type: CNAME
   value: f26d5a89-7b4d-4650-b10a-f350a4801568.id.repl.co.
+  
+wwww:
+  type: CNAME
+  value: eilla1.github.io.

--- a/dinosaurbbq.org.yaml
+++ b/dinosaurbbq.org.yaml
@@ -2,7 +2,6 @@
 www:
   type: CNAME
   value: f26d5a89-7b4d-4650-b10a-f350a4801568.id.repl.co.
-  
 wwww:
   type: CNAME
   value: eilla1.github.io.


### PR DESCRIPTION
I am proposing to add a `wwww` subdomain for `dinosaurbbq.org`. Feel free to reject if this doesn't fit the guidelines for what dinosaurbbq.org is supposed to be.
![733902c905](https://user-images.githubusercontent.com/72365100/136275969-681678c0-5289-4d10-ac46-1d46381d362a.png)