### PR TITLE
Change rhs subdomain to cken

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -450,6 +450,10 @@ ciudalcampo:
 - ttl: 1
   type: CNAME
   value: code-sekcc.github.io.
+cken:
+- ttl: 1
+  type: A
+  value: 52.191.165.18
 coet:
 - ttl: 1
   type: CNAME
@@ -1085,10 +1089,6 @@ ref.guide:
   ttl: 1
   type: CNAME
   value: symmetrical-potatoe-xe9q1l2s6ikk2wmjs2c7obnj.herokudns.com.
-rhs:
-- ttl: 1
-  type: A
-  value: 52.191.165.18
 riverbend:
 - ttl: 1
   type: CNAME


### PR DESCRIPTION
Per school rules, I'm not allowed to have a website be directly associated with a school club without approval. I've been told that getting this approval is difficult, so instead I'm opting to convert it to a personal but hack club-focused website. Thanks!