### PR TITLE
Add subdomain for muse.hackclub.com pointing to GitHub Pages

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1002,8 +1002,8 @@ mumble:
   type: A
   value: 173.208.140.124
 muse:
-  - type CNAME
-  - value: hackclub.github.io.
+- type CNAME
+  value: hackclub.github.io.
 mw:
 - ttl: 1
   type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1003,7 +1003,7 @@ mumble:
   value: 173.208.140.124
 muse:
 - type:  CNAME
-  value: hackclub.github.io.
+  value: cname.vercel-dns.com.
 mw:
 - ttl: 1
   type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1002,7 +1002,7 @@ mumble:
   type: A
   value: 173.208.140.124
 muse:
-- type CNAME
+- type:  CNAME
   value: hackclub.github.io.
 mw:
 - ttl: 1

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1001,6 +1001,9 @@ mumble:
 - ttl: 1
   type: A
   value: 173.208.140.124
+muse:
+  - type CNAME
+  - value: hackclub.github.io.
 mw:
 - ttl: 1
   type: CNAME


### PR DESCRIPTION
FYI @leomcelroy / @cedric-h, I'm moving the GitHub Pages hosting for Muse from https://hackclub.github.io/muse / https://muse.hackclub.dev to https://muse.hackclub.com.

Everything should get redirected appropriately, and I'll update the links in the Muse README and links on the GitHub repo too.