### PR TITLE
Add www.gamelab

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1561,6 +1561,10 @@ workshops:
 - ttl: 1
   type: CNAME
   value: cname.vercel-dns.com.
+www.gamelab:
+- ttl: 1
+  type: CNAME
+  value: cname.vercel-dns.com.
 www.gita:
 - ttl: 1
   type: A


### PR DESCRIPTION
(set up in Vercel to redirect to gamelab.hackclub.com)

Seems like this [link](https://github.com/hackclub/hackclub/blob/12d22b2355d6e4208254d48f23dae308336ab4c8/workshops/gamelab/README.md?plain=1#L12) in the Workshop links to www.gamelab.hackclub.com which isn't set up currently. This PR adds the CNAME record for that, but I'm not sure if this is desired or if the link in the workshop is just a typo.