### PR TITLE
commenting out the wildcard to vercel

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -46,10 +46,10 @@
   - v=spf1 include:_spf.google.com ~all
   - "00071672" # vercel verification code
 
-"*": # wildcard redirect
-  ttl: 1
-  type: CNAME
-  value: cname.vercel-dns.com.
+# "*": # wildcard redirect
+#   ttl: 1
+#   type: CNAME
+#   value: cname.vercel-dns.com.
 
 andrew: # by https://github.com/anddddrew
   ttl: 1


### PR DESCRIPTION
I'm removing the wildcard `*` CNAME record to vercel to prevent abuse. if you're impacted by this feel free to create a PR adding it for your domain.