### PR TITLE
Update zguide.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1628,7 +1628,7 @@ zephyrnet:
 zguide:
 - ttl: 1
   type: CNAME
-  value: yodalightsabr.github.io.
+  value: hackclub.github.io.
 zh:
 - ttl: 1
   type: CNAME


### PR DESCRIPTION
Update the DNS to match the transfer from YodaLightsabr/slashz-guide to hackclub/slash-z-guide