### PR TITLE
Utilize abandondoned domain austin.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -320,7 +320,7 @@ assets:
 austin:
   ttl: 1
   type: CNAME
-  value: ayushi-k8.github.io.
+  value: edge.redirect.pizza.
 australia:
   ttl: 1
   type: CNAME


### PR DESCRIPTION
CC @kpanjolia 

I'd like to use austin.hackclub.com as it seems to be currently unused by the original "claimant" ? I currently run a Hack Club that is open to all teens in Austin, and would like to use austin.hackclub.com as the website address for it.

Thanks!

--reese