### PR TITLE
Move Bank changelog to `bank.engineering`

### DIFF
--- a/bank.engineering.yaml
+++ b/bank.engineering.yaml
@@ -1,0 +1,5 @@
+---
+changelog:
+  ttl: 1
+  type: CNAME
+  value: headwayapp.co.


### PR DESCRIPTION
It'd be great if the Hack Club Bank change log was at `changelog.bank.engineering` rather than `changelog.bank.hackclub.com`.

1. Merge this PR
2. Add redirect from `changelog.bank.hackclub.com/$1` to `changelog.bank.engineering/$1`.
3. Make custom domain switch on Headway (https://docs.headwayapp.co/custom-domain)
4. Update widget and links in `hackclub/bank` repo with new domain