### PR TITLE
Update brasil.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -446,7 +446,7 @@ bqogdt6xkltngfg62lq7jo5dk33zerss._domainkey:
 brasil:
   ttl: 1
   type: CNAME
-  value: hackclub-brasil.netlify.app.
+  value: hack-club-brasil.netlify.app.
 bucky:
   - ttl: 1
     type: CNAME


### PR DESCRIPTION
Hello there! I am sending this PR because currently our website is deployed at Netlify in a user (Vitor's user) that I don't have access. Until a few days ago, that was ok, because it was deploying automatically from [our repository](https://github.com/hack-club-brasil/v1), but recently Netlify removed support of the image that was being used to deploy it and without access to the project I couldn't update it.

So I created a new project under my control where I fixed it and I am updating brasil.hackclub.com to point to it.

