### PR TITLE
Park social.dino.icu

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -220,7 +220,7 @@ spider: # spider.dino.icu; reserved by hack club bank
 social:
   ttl: 1
   type: ALIAS
-  value: parking.obl.ong
+  value: parking.obl.ong.
   
 stickers: # by https://github.com/lem6ns
   ttl: 1

--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -217,6 +217,11 @@ spider: # spider.dino.icu; reserved by hack club bank
   - google-site-verification=i1xM1TEj6jJSVo8p9s8oGmSZW2Wo2MIyxhyb007OAuA
   - v=spf1 include:_spf.google.com ~all
 
+social:
+  ttl: 1
+  type: ALIAS
+  value: parking.obl.ong
+  
 stickers: # by https://github.com/lem6ns
   ttl: 1
   type: CNAME


### PR DESCRIPTION
We (#mastodon-dev) decided to use social.dino.icu as the domain name for our mastodon instance.  I am parking it here for now.