### PR TITLE
Update `cchshackclub` to `cchs`

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -237,6 +237,8 @@ _vercel:
     - vc-domain-verify=register.epochvt.hackclub.com,8e89fd1c0e1dd7045bd5
     - vc-domain-verify=epochvt.hackclub.com,089353b4de0bf145067d
     - vc-domain-verify=epochba.hackclub.com,705735e32a03c39fdd26
+    - vc-domain-verify=cchs.hackclub.com,7f5caa162108e7253705
+    - vc-domain-verify=more.cchs.hackclub.com,c48f5d96baaeed884bbd
 
 a5fj644skxexxgvvraqrag5ngcaovcny._domainkey:
   ttl: 1
@@ -504,7 +506,6 @@ cccs:
   type: CNAME
   value: cname.vercel-dns.com.
 cchs:
-  - ttl: 1
     type: CNAME
     value: cname.vercel-dns.com.
 cdn:

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -503,10 +503,10 @@ cca:
 cccs:
   type: CNAME
   value: cname.vercel-dns.com.
-cchshackclub:
+cchs:
   - ttl: 1
     type: CNAME
-    value: cchshackclub.github.io.
+    value: cname.vercel-dns.com.
 cdn:
   type: CNAME
   value: cname.vercel-dns.com.


### PR DESCRIPTION
Members are having a bit of trouble finding `cchshackclub.hackclub.com`, so I thought it would be easier to shorten it.