### PR TITLE
Added libre.hackclub.com subdomain

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1191,6 +1191,15 @@ lhscc:
   - ttl: 1
     type: A
     value: 174.86.1.223
+libre:
+  - ttl: 1
+    type: NS
+    values:
+      - ns1.he.net.
+      - ns2.he.net.
+      - ns3.he.net.
+      - ns4.he.net.
+      - ns5.he.net.
 liftoff:
   - ttl: 1
     type: CNAME


### PR DESCRIPTION
I intend to use this subdomain, libre.hackclub.com, with my Winter of Making project, "[Libre Web Services (LWS)](https://github.com/hackclub/winter/blob/main/alialiwa2005.md)."