### PR TITLE
Remove Segment verification

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -27,7 +27,6 @@
       - google-site-verification=2979FUSGCz-WxnW6EukLx_N_Ay31YOyGBnvUSbwHcXc
       - v=spf1 include:_spf.google.com include:mailgun.org include:amazonses.com include:sendgrid.net ~all
       - AA418B02F6
-      - segment-site-verification=ED0mCO5yaFBc40hEvipDG5OiON3Nemh2
       - stripe-verification=5bdd0e2475b12744bfe1f778ac419f917800d476fd498ae2682ecd161d162c64
       - 61220A24D7 # From Expensify
       - 2610E0D36E # From Expensify


### PR DESCRIPTION
We don't actively use Segment anymore, so this removes the TXT record that is taking up space