### PR TITLE
Update status.hackclub.com to new Checkly CNAME

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1805,7 +1805,7 @@ statehigh:
 status:
   - ttl: 1
     type: CNAME
-    value: dashboards.checklyhq.com.
+    value: checkly-dashboards.com.
 status.haas:
   type: A
   value: 34.138.52.92


### PR DESCRIPTION
Checkly has a new CNAME domain