### PR TITLE
Revert "Update status.hackclub.com to new Checkly CNAME"

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1805,7 +1805,7 @@ statehigh:
 status:
   - ttl: 1
     type: CNAME
-    value: checkly-dashboards.com.
+    value: dashboards.checklyhq.com.
 status.haas:
   type: A
   value: 34.138.52.92


### PR DESCRIPTION
Reverts hackclub/dns#868

Seems like [proxyparty](https://github.com/hackclub/proxyparty) is interfering with this set up. Reverting to the old Checkly dashboard for now