### PR TITLE
Change dash.hackathons to load balancer, add server IPs

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -725,6 +725,10 @@ codethetech:
 dash.hackathons:
   ttl: 1
   type: A
+  value: 5.161.160.54
+app-1.hackathons
+  ttl: 1
+  type: A
   value: 5.161.229.50
 daysofservice:
   ttl: 1

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -726,7 +726,7 @@ dash.hackathons:
   ttl: 1
   type: A
   value: 5.161.160.54
-app-1.hackathons
+app-1.hackathons:
   ttl: 1
   type: A
   value: 5.161.229.50


### PR DESCRIPTION
dash.hackathons.hackclub.com is now being powered by a [Hetzner load balancer](https://www.hetzner.com/cloud/load-balancer), which offers more flexibility.