### PR TITLE
delete poolesville.hackclub.com so i can add it to vercel

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1731,10 +1731,6 @@ pomperaug:
   ttl: 1
   type: CNAME
   value: cname.vercel-dns.com.
-poolesville:
-  ttl: 1
-  type: CNAME
-  value: cname.vercel-dns.com.
 portal.ctf:
   ttl: 1
   type: A


### PR DESCRIPTION
I was the one who added poolesville.hackclub.com
<img width="848" alt="image" src="https://github.com/hackclub/dns/assets/66806100/0b039847-3a58-4e38-9a61-307131ce5a24">
