### PR TITLE
Revert "Add Boston Latin School (BLS HACK)"

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -533,10 +533,6 @@ blog.ctrl-alt-tec:
   - ttl: 1
     type: CNAME
     value: ctrl-alt-tec.github.io.
-bls:
-  - ttl: 1
-    type: CNAME
-    value: v-iinh.github.io/hackclub-site.
 bn:
   - ttl: 1
     type: CNAME


### PR DESCRIPTION
Reverts hackclub/dns#996

Rolling this back temporarily while trying to fix deployments. Sorry @ilyKcaj! It'll get merged back in as soon as we fix this