### PR TITLE
OCSA hack club website

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1642,6 +1642,12 @@ nust:
   - ttl: 1
     type: CNAME
     value: nusthackclub.netlify.app.
+ocsa:
+  - ttl: 1
+    type: TXT
+    values:
+      - google-site-verification=O2LlohyBOM3x0c_m9P7sn14o12H802WsaNle7XIY3QE
+    
 oly:
   - ttl: 1
     type: A

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1647,7 +1647,10 @@ ocsa:
     type: TXT
     values:
       - google-site-verification=O2LlohyBOM3x0c_m9P7sn14o12H802WsaNle7XIY3QE
-    
+  - ttl: 300
+    type: CNAME
+    values:
+      - ghs.googlehosted.com.
 oly:
   - ttl: 1
     type: A

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1645,12 +1645,8 @@ nust:
 ocsa:
   - ttl: 1
     type: TXT
-    values:
-      - google-site-verification=O2LlohyBOM3x0c_m9P7sn14o12H802WsaNle7XIY3QE
-  - ttl: 300
-    type: CNAME
-    values:
-      - ghs.googlehosted.com.
+    value: google-site-verification=O2LlohyBOM3x0c_m9P7sn14o12H802WsaNle7XIY3QE
+
 oly:
   - ttl: 1
     type: A


### PR DESCRIPTION
This is the website for OCSA's Hack Club.  We hope to make this a hub for our clubs resources, including meeting slides and contact information.