### PR TITLE
Update records for outerlan.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1689,19 +1689,8 @@ orpheushacks: # Harrison Katz automatically wins for adding the DNS entry - that
     value: cname.vercel-dns.com.
 outerlan:
   - ttl: 1
-    type: A
-    values:
-      - 185.199.108.153
-      - 185.199.109.153
-      - 185.199.110.153
-      - 185.199.111.153
-  - ttl: 1
-    type: AAAA
-    values:
-      - 2606:50c0:8000::153
-      - 2606:50c0:8001::153
-      - 2606:50c0:8002::153
-      - 2606:50c0:8003::153
+    type: CNAME
+    value: hackclub.github.io
 outernet:
   - ttl: 1
     type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1690,7 +1690,7 @@ orpheushacks: # Harrison Katz automatically wins for adding the DNS entry - that
 outerlan:
   - ttl: 1
     type: CNAME
-    value: hackclub.github.io
+    value: hackclub.github.io.
 outernet:
   - ttl: 1
     type: CNAME


### PR DESCRIPTION
![image](https://github.com/hackclub/dns/assets/62346025/d32f145c-0ed7-461f-97ba-9610c3a2633b)

It turns out that you need to use a CNAME record or GitHub will not provision the site at all

![image](https://github.com/hackclub/dns/assets/62346025/d819c78f-da7e-4e94-a5a1-6ea9bf38442d)
