### PR TITLE
change DNS setup from Netlify to Vercel for ALOPB club

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -274,6 +274,7 @@ _vercel:
     - vc-domain-verify=ihs.hackclub.com,21e13c0c6af87766f6f5
     - vc-domain-verify=poolesville.hackclub.com,d8099895eaea670eec60
     - vc-domain-verify=wonderland.hackclub.com,0c2e35e271cd0c23752d
+    - vc-domain-verify=alopb.hackclub.com,4e5088446aea4b3d4559
 a5fj644skxexxgvvraqrag5ngcaovcny._domainkey:
   ttl: 1
   type: CNAME
@@ -294,10 +295,6 @@ aloha:
   - ttl: 1
     type: CNAME
     value: epic-mcnulty-0ed53c.netlify.app.
-alopb:
-  - ttl: 1
-    type: CNAME
-    value: alopb.netlify.app.
 alpharetta:
   - ttl: 1
     type: A


### PR DESCRIPTION
We changed our DNS configuration because the Netlify ALOPB club domain was somehow reserved and we could not use HC DNS.