### PR TITLE
Verify ALOPB Hack Club domain for GitHub organization

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -123,6 +123,10 @@ _dmarc:
   ttl: 1
   type: TXT
   value: v=DMARC1\; p=quarantine\; rua=mailto:6192c543e0e61@ag.dmarcly.com\; ruf=mailto:6192c543e0e61@fo.dmarcly.com\; fo=1\;
+_github-challenge-ALOPB-Hack-Club-org.alopb:
+  - ttl: 1
+    type: TXT
+    value: 8c323c2c39
 _github-challenge-GaynorMcCown.gaynormccown:
   - ttl: 1
     type: TXT


### PR DESCRIPTION
Organization: https://github.com/ALOPB-Hack-Club
Domain: https://alopb.hackclub.com