### PR TITLE
Add wildcard for Nest user subdomains

### DIFF
--- a/hackclub.app.yaml
+++ b/hackclub.app.yaml
@@ -2,6 +2,9 @@
 "":
   - type: A
     value: 37.27.51.34
+"*":
+  - type: CNAME
+    value: hackclub.app.
 secure:
   - type: A
     value: 37.27.51.33


### PR DESCRIPTION
This routes to the Nest VM on the server, which will be handled by Caddy for Nest users.