### PR TITLE
Set up t.hackclub.org to manage email campaign performance

### DIFF
--- a/hackclub.org.yaml
+++ b/hackclub.org.yaml
@@ -17,3 +17,6 @@
 '*':
   type: CNAME
   value: proxyparty.hackclub.com.
+'t':
+  type: CNAME
+  value: custom.lemlist.com


### PR DESCRIPTION
I am experimenting with cold outreach to libraries, makerspaces, and teachers, and setting up t.hackclub.org to see opens and clicks on emails.

These emails are only external, and don't go to Hack Clubbers. We don't track those at all.