### PR TITLE
Revert "Add Orpheus Odyessy"

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1735,10 +1735,6 @@ orpheushacks: # Harrison Katz automatically wins for adding the DNS entry - that
   - ttl: 1
     type: CNAME
     value: cname.vercel-dns.com.
-orpheusodyssey: # We are from the-summit
-  - ttl: 1
-    type: A
-    value: 10.11.21.43
 outerlan:
   - ttl: 1
     type: CNAME


### PR DESCRIPTION
Reverts hackclub/dns#1068

This is due to it being a private IP address (10.x range). 