### PR TITLE
Change url to one specifically configured for hack.club in heroku

### DIFF
--- a/hack.club.yaml
+++ b/hack.club.yaml
@@ -1,4 +1,4 @@
 ---
 "":
   - type: ALIAS
-    value: adjacent-crag-9vk67y6ktr6zzlqitcb2fxwn.herokudns.com.
+    value: solid-daffodil-0mn798giomwnltj8ssbu2xb6.herokudns.com.


### PR DESCRIPTION
Fixes an issue where ssl is messed up and host doesn't resolve properly to heroku as a result