### PR TITLE
Add `sheetparty.hackclub.app`

### DIFF
--- a/hackclub.app.yaml
+++ b/hackclub.app.yaml
@@ -23,3 +23,6 @@ guides:
 identity:
   - type: CNAME
     value: secure.hackclub.app.
+sheetparty:
+  - type: A
+    value: 37.27.51.34


### PR DESCRIPTION
This PR adds an A record to `sheetparty.hackclub.app` pointing to nest, which is hosting the web server for the spreadsheet party site.