### PR TITLE
Update README with recommended TTL of 600s

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository is used for managing Hack Club's DNS configuration through [Octo
 
 ```yaml
 SUBDOMAIN_NAME:
-  - ttl: 1
+  - ttl: 600
     type: CNAME
     value: SOURCE_DOMAIN_OR_IP.
 ```
@@ -43,7 +43,7 @@ Add the value to the [hackclub.com.yaml](./hackclub.com.yaml) file as shown belo
 
 ```yaml
 _vercel:
-  ttl: 1
+  ttl: 600
   type: TXT
   values:
     - vc-domain-verify=wackclub.hackclub.com,423c28e0fbdd51449cf1


### PR DESCRIPTION
This PR updates the recommended TTL on the readme from 1 second (no caching) to 600 seconds (10 minutes). Related to #1023 