### PR TITLE
Revert "create pizza.hackclub.com"

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2601,11 +2601,6 @@ codecafe:
 - ttl: 1
   type: CNAME 
   value: cname.vercel-dns.com.
-  
-pizza:
-- ttl: 1
-  type: CNAME
-  value: hackclub.com/pizza.
 
 internal:
 - ttl: 1


### PR DESCRIPTION
Reverts hackclub/dns#1094

This PR is causing deploy issues at the moment, due to the invalid CNAME formatting (no pathname in CNAMEs, that's not how they work)