### PR TITLE
Add `aux.dinosaurbbq.org`

### DIFF
--- a/dinosaurbbq.org.yaml
+++ b/dinosaurbbq.org.yaml
@@ -8,3 +8,6 @@ www:
 wwww:
   type: CNAME
   value: exu3.github.io.
+aux:
+  type: A
+  value: 136.62.158.195


### PR DESCRIPTION
This PR adds `aux.dinosaurbbq.org` to support the OrpheAUX radio server for hack-night!