### PR TITLE
Fix error in hackclub.com.yaml

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -425,9 +425,6 @@ asiet:
     value: kkharidev.github.io.
 asmgame:
   - ttl: 3600
-    type: ALIAS
-    value: hackclub.github.io.
-  - ttl: 3600
     type: A
     values:
       - 185.199.108.153


### PR DESCRIPTION
DNSimple doesn't allow ALIAS records to co-exist with other records with the same name