### PR TITLE
Adding status.hcb.hackclub.com — HCB Status Page (AppSignal)

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2216,6 +2216,10 @@ status:
 status.haas:
   type: A
   value: 34.138.52.92
+status.hcb:
+  - ttl: 1
+    type: CNAME
+    value: cname.appsignal-status.com
 stemegypt:
   - ttl: 900
     type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2219,7 +2219,7 @@ status.haas:
 status.hcb:
   - ttl: 1
     type: CNAME
-    value: cname.appsignal-status.com
+    value: cname.appsignal-status.com.
 stemegypt:
   - ttl: 900
     type: CNAME


### PR DESCRIPTION
# Adding status.hcb.hackclub.com

## Description

HCB's status monitoring has moved to AppSignal. We're setting up a public monitoring dashboard
