### PR TITLE
Adding evergreen.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1041,6 +1041,10 @@ events:
   ttl: 1
   type: CNAME
   value: cname.vercel-dns.com.
+evergreen:
+  - ttl: 1
+    type: CNAME
+    value: cname.vercel-dns.com.
 evoking:
   ttl: 1
   type: CNAME


### PR DESCRIPTION
This subdomain will be used for the upcoming Seattle DOS on May 3rd.
