### PR TITLE
Adding cghs.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -691,6 +691,10 @@ cgc:
   - ttl: 1
     type: CNAME
     value: hackclubcgc.netlify.app.
+cghs:
+  - ttl: 600
+  - type: CNAME
+  - value: cghs-hackclub.github.io
 changelog.bank:
   ttl: 1
   type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -694,7 +694,7 @@ cgc:
 cghs:
   - ttl: 600
   - type: CNAME
-  - value: cghs-hackclub.github.io
+    value: cghs-hackclub.github.io
 changelog.bank:
   ttl: 1
   type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -693,7 +693,7 @@ cgc:
     value: hackclubcgc.netlify.app.
 cghs:
   - ttl: 600
-  - type: CNAME
+    type: CNAME
     value: cghs-hackclub.github.io
 changelog.bank:
   ttl: 1

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -694,7 +694,7 @@ cgc:
 cghs:
   - ttl: 600
     type: CNAME
-    value: cghs-hackclub.github.io
+    value: cghs-hackclub.github.io.
 changelog.bank:
   ttl: 1
   type: CNAME


### PR DESCRIPTION
# Adding `cghs.hackclub.com`

## Description

added the entry for cghs.hackclub.com

this will be the subdomain for my highschool's hack club website, where we can provide information and resources, along with links and information on how to join. 

you can check out the existing website at [cghs-hackclub.github.io](https://cghs-hackclub.github.io/). its currently in the process of being updated, and isn't in a fully functional state right now.

Thanks!