### PR TITLE
Deleting `summit.hackclub.app`

### DIFF
--- a/hackclub.app.yaml
+++ b/hackclub.app.yaml
@@ -18,9 +18,6 @@ secure:
     value: 37.27.51.33
   - type: AAAA
     value: 2a01:4f9:3081:399c::3
-summit:
-  - type: CNAME
-    value: cname.vercel-dns.com.
 ts:
   - type: CNAME
     value: secure.hackclub.app.


### PR DESCRIPTION
# Deleting `summit.hackclub.app`

## Description

Removes summit.hackclub.app, which was used for Summit registration, but is no longer needed on hackclub.app.
