### PR TITLE
Updating `hackclub.app`

### DIFF
--- a/hackclub.app.yaml
+++ b/hackclub.app.yaml
@@ -14,13 +14,13 @@
     values:
       - algorithm: 1
         fingerprint_type: 2
-        fingerprint: "9LNUl0XK2uImngAShvC5n/EdT/DuazOoMArZ+XN/1Ls"
+        fingerprint: "f4b3549745cadae2269e001286f0b99ff11d4ff0ee6b33a8300ad9f9737fd4bb"
       - algorithm: 3
         fingerprint_type: 2
-        fingerprint: "C89oJuxXbCpfFwuBZC2UMCzch0QKLenaAiSNuiZVoJw"
+        fingerprint: "0bcf6826ec576c2a5f170b81642d94302cdc87440a2de9da02248dba2655a09c"
       - algorithm: 4
         fingerprint_type: 2
-        fingerprint: "HMpqihlnZErDu5whsf8PbhYPSjUGf+KK++zhmSfDADo"
+        fingerprint: "1cca6a8a1967644ac3bb9c21b1ff0f6e160f4a35067fe28afbece19927c3003a"
 "*":
   - type: CNAME
     value: hackclub.app.


### PR DESCRIPTION
# Updating `hackclub.app`

## Description

This PR attempts to fix the Nest SSHFP records again as they seem to have been causing the DNS workflows to fail. These values were generated with `ssh-keygen -r hackclub.app.` and confirmed with `ssh-keyscan -D hackclub.app`.
