### PR TITLE
Adding oasis.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1777,6 +1777,10 @@ nust:
   - ttl: 600
     type: CNAME
     value: nusthackclub.netlify.app.
+oasis:
+  - ttl: 600
+    type: CNAME
+    value: cname.vercel-dns.com.
 ocsa:
   - ttl: 3600
     type: TXT


### PR DESCRIPTION
Adding a subdomain for Oasis, the Austin (TX) Day of Service.
