### PR TITLE
Add hcarc.hackclub.com MX and supporting records

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1331,7 +1331,7 @@ hcarc:
 _dmarc.hcarc:
   type: TXT
   ttl: 600
-  value: "v=DMARC1\; p=quarantine\;"
+  value: "v=DMARC1\\; p=quarantine\\;"
 key1._domainkey.hcarc:
   type: CNAME
   ttl: 600

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1328,7 +1328,7 @@ hcarc:
     values:
       - hosted-email-verify=czorstw1
       - v=spf1 include:spf.migadu.com -all
-_dmarc:
+_dmarc.hcarc:
   type: TXT
   ttl: 600
   value: "v=DMARC1\; p=quarantine\;"

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1319,9 +1319,9 @@ hcarc:
   - type: MX
     ttl: 600
     values:
-      - exchange: aspmx1.migadu.com
+      - exchange: aspmx1.migadu.com.
         preference: 10
-      - exchange: aspmx2.migadu.com
+      - exchange: aspmx2.migadu.com.
         preference: 20
   - type: TXT
     ttl: 600

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1331,7 +1331,7 @@ hcarc:
 _dmarc:
   type: TXT
   ttl: 600
-  value: v=DMARC1; p=quarantine;
+  value: "v=DMARC1\; p=quarantine\;"
 key1._domainkey.hcarc:
   type: CNAME
   ttl: 600

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1314,6 +1314,37 @@ harvest:
 haxidraw:
   type: CNAME
   value: cname.vercel-dns.com.
+
+hcarc:
+  - type: MX
+    ttl: 600
+    values:
+      - exchange: aspmx1.migadu.com
+        preference: 10
+      - exchange: aspmx2.migadu.com
+        preference: 20
+  - type: TXT
+    ttl: 600
+    values:
+      - hosted-email-verify=czorstw1
+      - v=spf1 include:spf.migadu.com -all
+_dmarc:
+  type: TXT
+  ttl: 600
+  value: v=DMARC1; p=quarantine;
+key1._domainkey.hcarc:
+  type: CNAME
+  ttl: 600
+  value: key1.hcarc.hackclub.com._domainkey.migadu.com.
+key2._domainkey.hcarc:
+  type: CNAME
+  ttl: 600
+  value: key2.hcarc.hackclub.com._domainkey.migadu.com.
+key3._domainkey.hcarc:
+  type: CNAME
+  ttl: 600
+  value: key3.hcarc.hackclub.com._domainkey.migadu.com.
+      
 hcb:
   - type: ALIAS
     value: rocky-jackfruit-11wv1arsenhczo2z58bae8lt.herokudns.com.


### PR DESCRIPTION
<!--
This is a template, please modify it to fit your Pull Request. 

Please pick one option when multiple are presented in brackets.

Please title your PR like this: [Adding/Deleting/Updating] `subdomain.[hackclub.com/dino.icu/etc]`
-->

# Adding `hcarc.hackclub.com`

## Description

This change supports email on hcarc.hackclub.com on Migadu as a temporary solution while HCB runs out the google workspace waitlist. When the waitlist is complete, the MX and supporting records will be updated to Google Workspace. Until that happens, only one address will exist to facilitate interactions with the FCC.