### PR TITLE
Adding subdomain.forge.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -370,6 +370,10 @@ angelhacksla:
   - ttl: 600
     type: CNAME
     value: cname.vercel-dns.com.
+forge:
+  - ttl: 600
+    type: CNAME
+    value: cname.vercel-dns.com.
 ama-machine:
   - ttl: 600
     type: CNAME


### PR DESCRIPTION
<!--
This is a template, please modify it to fit your Pull Request. 

Please pick one option when multiple are presented in brackets.

-->

Adding subdomain.forge.hackclub.com #1211

## Description 

A site for Forge, an upcoming YSWS targeting additive manufacturing and programmatic modeling. You solve a problem using our custom OpenSCAD-based modeling software and you get to build a Forge 3D printer. The Forge is a mostly custom cantilevered printer with a unique motion system and the ability to fold into a filament box. This printer adds features such as ABL, G10, a Sherpa Mini DDE, and WiFi. Featuring a custom engineered mainboard featuring a RP2040 and TMC2209s with a custom firmware.