### PR TITLE
Updating hackclub.app

### DIFF
--- a/hackclub.app.yaml
+++ b/hackclub.app.yaml
@@ -5,11 +5,11 @@
   - type: AAAA
     value: 2a01:4f9:3081:399c::4
   - type: MX
-    values: 
+    values:
       - exchange: mail.hackclub.app.
         priority: 10
   - type: TXT
-    value: "v=spf1 mx ~all" 
+    value: "v=spf1 mx ~all"
   - type: SSHFP
     values:
       - algorithm: 1
@@ -40,6 +40,11 @@ passwd.ts:
 pve.ts:
   - type: A
     value: 100.64.0.10
+  - type: AAAA
+    value: fd7a:115c:a1e0::a
+proxmox:
+  - type: A
+    value: 37.27.51.35
   - type: AAAA
     value: 2a01:4f9:3081:399c::2
 guides:


### PR DESCRIPTION
# Updating `hackclub.app`

## Description

This PR:
- updates the AAAA record for `pve.ts.hackclub.app` to reflect reality
- introduces `proxmox.hackclub.app`, which resolves to Nest's proxmox instance's public IP address
- removes two trailing spaces because `nano` was pointing them out
