### PR TITLE
Add summit.hackclub.app

### DIFF
--- a/hackclub.app.yaml
+++ b/hackclub.app.yaml
@@ -29,6 +29,9 @@ secure:
     value: 37.27.51.33
   - type: AAAA
     value: 2a01:4f9:3081:399c::3
+summit:
+  - type: CNAME
+    value: cname.vercel-dns.com.
 ts:
   - type: CNAME
     value: secure.hackclub.app.


### PR DESCRIPTION
Some things still link to it, and it would be good to provide a redirect instead of 

<img width="693" alt="image" src="https://github.com/hackclub/dns/assets/76178582/e3d40f3c-15d3-422a-af1b-eff5415e31fc">
