### PR TITLE
Updating hackstore.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1334,7 +1334,7 @@ hackinux:
 hackstore:
   ttl: 600
   type: CNAME
-  value: cname.vercel-dns.com.
+  value: hack-store.netlify.app.
 hacktheoctober:
   ttl: 600
   type: CNAME


### PR DESCRIPTION
# Updating `hackstore.hackclub.com`

## Description

Hack Store (the earlier one) is a discontinued project. The original organizers are no longer members of Hack Club (they literally completed their Graduation). A few Hack Clubbers and I are working on Hack Store where Hack Clubbers can upload their apps for free of cost unlike Google Play where they are required to pay $25 approx. to create a Dev Account. This store will act as a boost for other projects!