### PR TITLE
chore(dino.icu): Add DNS records for <ajhalili2006|andreijiroh>.dino.icu

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -52,6 +52,17 @@
 #   type: CNAME
 #   value: cname.vercel-dns.com.
 
+ajhalili2006: # by https://github.com/ajhalili2006 via https://github.com/andreijiroh-dev/website
+  - ttl: 600
+    type: CNAME
+    # redirects to https://andreijiroh.xyz via caddy config at https://github.com/recaptime-dev/proxyparty-caddy
+    value: proxyparty.recaptime.dev.
+
+andreijiroh: # by https://github.com/ajhalili2006, but uses his first name as subdomain instead of github username
+  - ttl: 600
+    type: CNAME
+    value: proxyparty.recaptime.dev.
+
 andrew: # by https://github.com/anddddrew
   ttl: 600
   type: CNAME


### PR DESCRIPTION
# Adding `ajhalili2006.dino.icu` and `andreijiroh.dino.icu`

Pardon the Conventional Commits style in the patch/merge request title.

## Description

So I am adding my website (it was obvious that I use [Material for Mkdocs](https://github.com/squidfunk/mkdocs-material) for the theming) under both `ajhalili2006` (my username) and `andreijiroh` (first name) subdomains. Please let me know if I should pick either one and I'll amend the commit later.

For technicalities behind the CNAME record, I'll be doing the redirects via my own Caddy config at https://github.com/recaptime-dev/proxyparty-caddy instead of setting up additional custom domains on my Cloudflare Pages project. (The Caddy server in question is hosted on an `e2-micro` GCP Compute Engine instance per https://github.com/recaptime-dev/proxyparty-caddy/blob/main/SETUP.md#gcp-compute-engine-vm.)
