### PR TITLE
deleting space after codingcrew.dino.icu hosting link

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -92,6 +92,11 @@ click: # a URL shortener
   type: CNAME
   value: cname.vercel-dns.com.
   
+codingcrew: # by https://github.com/shim-sham
+  ttl: 600 
+  type: CNAME
+  value: shim-sham.github.io/coding-crew. 
+  
 cslide: 
   ttl: 600
   type: CNAME

--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -95,7 +95,7 @@ click: # a URL shortener
 codingcrew: # by https://github.com/shim-sham
   ttl: 600 
   type: CNAME
-  value: shim-sham.github.io/coding-crew. 
+  value: lustrous-ganache-dbb807.netlify.app. 
   
 cslide: 
   ttl: 600

--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -95,7 +95,7 @@ click: # a URL shortener
 codingcrew: # by https://github.com/shim-sham
   ttl: 600 
   type: CNAME
-  value: lustrous-ganache-dbb807.netlify.app. 
+  value: lustrous-ganache-dbb807.netlify.app.
   
 cslide: 
   ttl: 600

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -772,11 +772,6 @@ codeabit:
     type: CNAME
     value: codeabitkw.github.io.
     
-codingcrew:
-  - ttl: 600
-    type: CNAME
-    value: shim-sham.github.io/coding-crew.
-    
 coet:
   - ttl: 600
     type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -771,6 +771,12 @@ codeabit:
   - ttl: 600
     type: CNAME
     value: codeabitkw.github.io.
+    
+codingcrew:
+  - ttl: 600
+    type: CNAME
+    value: shim-sham.github.io/coding-crew.
+    
 coet:
   - ttl: 600
     type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -772,6 +772,11 @@ codeabit:
     type: CNAME
     value: codeabitkw.github.io.
     
+codingcrew:
+  - ttl: 600
+    type: CNAME
+    value: shim-sham.github.io/coding-crew.
+    
 coet:
   - ttl: 600
     type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -770,8 +770,7 @@ cken:
 codeabit:
   - ttl: 600
     type: CNAME
-    value: codeabitkw.github.io.
-    
+    value: codeabitkw.github.io.  
 coet:
   - ttl: 600
     type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -771,12 +771,6 @@ codeabit:
   - ttl: 600
     type: CNAME
     value: codeabitkw.github.io.
-    
-codingcrew:
-  - ttl: 600
-    type: CNAME
-    value: shim-sham.github.io/coding-crew.
-    
 coet:
   - ttl: 600
     type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -770,7 +770,8 @@ cken:
 codeabit:
   - ttl: 600
     type: CNAME
-    value: codeabitkw.github.io.  
+    value: codeabitkw.github.io.
+    
 coet:
   - ttl: 600
     type: CNAME


### PR DESCRIPTION
My previous pr was for adding codingcrew.dino.icu, but I've realised that the link won't work since there's a space after lustrous-ganache-dbb807.netlify.app. I apologise for the inconvenience