### PR TITLE
Adding `_gh-arsenobetaine-o.arsenic.hackclub.com`

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -129,6 +129,10 @@ _dmarc:
   ttl: 600
   type: TXT
   value: v=DMARC1\; p=quarantine\; rua=mailto:6192c543e0e61@ag.dmarcly.com\; ruf=mailto:6192c543e0e61@fo.dmarcly.com\; fo=1\;
+_gh-arsenobetaine-o.arsenic:
+  - ttl: 600
+    type: TXT
+    value: 1f595876ef
 _github-challenge-ALOPB-Hack-Club-org.alopb:
   - ttl: 600
     type: TXT

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -430,14 +430,14 @@ archived.guide:
   ttl: 600
   type: CNAME
   value: hackclub-guide.netlify.com.
-aryan:
-  - ttl: 600
-    type: CNAME
-    value: cname.vercel-dns.com.
 arsenic:
   - ttl: 600
     type: CNAME
     value: arsenobetaine.github.io.
+aryan:
+  - ttl: 600
+    type: CNAME
+    value: cname.vercel-dns.com.
 asia-summit:
   - ttl: 600
     type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -434,6 +434,10 @@ aryan:
   - ttl: 600
     type: CNAME
     value: cname.vercel-dns.com.
+arsenic:
+  - ttl: 600
+    type: CNAME
+    value: arsenobetaine.github.io.
 asia-summit:
   - ttl: 600
     type: CNAME


### PR DESCRIPTION
# Adding `_gh-arsenobetaine-o.arsenic.hackclub.com`

## Description

This is to verify the `arsenic.hackclub.com` subdomain for the github organization!