### PR TITLE
Updating live.onboard.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1735,7 +1735,7 @@ list:
 live.onboard:
   - ttl: 600
     type: A
-    value: 195.201.227.192
+    value: 188.40.116.216
 lonestar:
   - ttl: 600
     type: CNAME


### PR DESCRIPTION
# Updating `live.onboard.hackclub.com`

## Description

Hello,

@grymmy recently upgraded the OnBoard Live VPS to a dedicated server for better streaming performance. As such, the IP has changed, so I'm making this PR to get the OBL subdomain to point at the new address. This won't be a regular occurrence.

Thank you!
