### PR TITLE
Update hackclub.com.yaml for epoch0 club

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -314,6 +314,7 @@ _vercel:
     - vc-domain-verify=lambert.hackclub.com,3e5d64ff4f6d55af2248
     - vc-domain-verify=bbss.hackclub.com,6c79bb5ffee8bbfd78d2
     - vc-domain-verify=ascend.hackclub.com,5c143e010cb754d62113
+    - vc-domain-verify=epoch0.hackclub.com,ff9cc22901478379593a
 a5fj644skxexxgvvraqrag5ngcaovcny._domainkey:
   ttl: 600
   type: CNAME
@@ -1067,6 +1068,10 @@ es:
   - ttl: 600
     type: A
     value: 76.76.21.21
+epoch0:
+  - ttl: 3600
+    type: TXT
+    value: zoho-verification=zb71957826.zmverify.zoho.in.
 epoch:
   - ttl: 600
     type: ALIAS


### PR DESCRIPTION
# [Adding] `epoch0.hackclub.com`

## Description

This PR adds DNS records for the Epoch0 Club, enabling email verification and Vercel hosting. The addition of these records will enhance the club's digital presence and functionality.

### Changes:
- **epoch0**:
  - **TTL**: 3600
  - **Type**: TXT
  - **Value**: `zoho-verification=zb71957826.zmverify.zoho.in.`
  - **Value**: `vc-domain-verify=epoch0.hackclub.com,ff9cc22901478379593a`