### PR TITLE
Adding `barracoders.hackclub.com`

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -589,6 +589,10 @@ bank-wrapped:
   - ttl: 600
     type: CNAME
     value: cname.vercel-dns.com.
+barracoders:
+  - ttl: 600
+    type: CNAME
+    value: barracoders.netlify.app.
 bbss:
   - ttl: 600
     type: CNAME


### PR DESCRIPTION
# Adding `barracoders.hackclub.com`

## Description

I added the `barracoders.hackclub.com` subdomain due to out school blocking `barracoders.com` and not blocking any `.hackclub.com` subdomain. This website will allow my club to access important information about clubs meets and upcoming events and a place to share thier creations.
