### PR TITLE
Adding qr.dino.icu

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -335,6 +335,11 @@ print:
    type: CNAME
    value: cname.vercel-dns.com.
 
+qr: # A hack club themed QR code generator
+  ttl: 600
+  type: CNAME
+  value: felixgao.hackclub.app.
+
 rr: # Rickroll with a single line of bash
   ttl: 600
   type: CNAME


### PR DESCRIPTION
# Adding qr.dino.icu

## Description

A QR code generator. You can make Hack Club themed QR codes and easily download them _without_ being registered to a mailing list!

![image](https://github.com/user-attachments/assets/2f85c09d-d707-41d7-9a47-bb889ee20f9b)

Find a demo at [qr.felixgao.dev](https://qr.felixgao.dev)