### PR TITLE
Adding legacy.verify.onboard.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1747,6 +1747,10 @@ leap-manual:
   - ttl: 600
     type: CNAME
     value: cname.vercel-dns.com.
+legacy.verify.onboard:
+  - ttl: 5000
+    type: CNAME
+    value: legacy.verify.onboard.limeskey.com.
 lghs:
   - ttl: 600
     type: CNAME


### PR DESCRIPTION
# Adding `legacy.verify.onboard.hackclub.com`
## Description
Legacy verification form that redirects to the airtable form
