### PR TITLE
Add domain verification for runshaw.ac.uk

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2382,6 +2382,10 @@ runshaw:
   - ttl: 600
     type: CNAME
     value: dragon863.hackclub.app.
+  - ttl: 600
+    type: TXT
+    values:
+      - domain-verification=dragon863
 s1._domainkey:
   ttl: 600
   type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2380,8 +2380,8 @@ ru:
     value: cname.vercel-dns.com.
 runshaw:
   - ttl: 600
-    type: CNAME
-    value: dragon863.hackclub.app.
+    type: ALIAS
+    value: hackclub.app.
   - ttl: 600
     type: TXT
     values:


### PR DESCRIPTION
# Updating `runshaw.hackclub.com`

## Description

Hi again! Nest requires me to add a TXT record for domain verification before I can set up the reverse proxy to work correctly. Thank you!