### PR TITLE
Adding philippines.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -329,6 +329,7 @@ _vercel:
     - vc-domain-verify=manor.hackclub.com,c99d993e9a9687a44549
     - vc-domain-verify=celestial.hackclub.com,712c9345didfd5e0b4ee
     - vc-domain-verify=awest.hackclub.com,e6d12d504df9bbb88908
+    - vc-domain-verify=philippines.hackclub.com,8ce6b0b9767789ac9e92
 a5fj644skxexxgvvraqrag5ngcaovcny._domainkey:
   ttl: 600
   type: CNAME
@@ -2176,6 +2177,10 @@ philanthropy:
   ttl: 600
   type: CNAME
   value: cname.vercel-dns.com.
+philippines:
+  - ttl: 600
+    type: CNAME
+    value: cname.vercel-dns.com.
 phs:
   - ttl: 600
     type: ALIAS


### PR DESCRIPTION
# Adding `philippines.hackclub.com`

## Description
The subdomain **philippines.hackclub.com** will be used to a website dedicated for the latest hackathons and any hackclub-related events in the Philippines. With the use of the said website, it can spread information about hackclub and it can engage more high schoolers to organize their own hackathons and start their own club at their respective schools. 
