### PR TITLE
Update runshaw.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2389,8 +2389,14 @@ ru:
     value: cname.vercel-dns.com.
 runshaw:
   - ttl: 600
-    type: CNAME
-    value: dragon863.hackclub.app.
+    type: A
+    value: 37.27.51.34
+  - ttl: 600
+    type: AAAA
+    value: 2a01:4f9:3081:399c::4
+  - ttl: 600
+    type: TXT
+    value: domain-verification=dragon863
 s1._domainkey:
   ttl: 600
   type: CNAME


### PR DESCRIPTION
# Updating `runshaw.hackclub.com`

## Description

After a [failed and reverted attempt](https://github.com/hackclub/dns/pull/1349) to route this subdomain to the Nest server I've been advised to instead try directly using an A and AAAA record. This PR replaces the CNAME with the appropriate TXT, A and AAAA records. This is all according to the [Nest documentation](https://guides.hackclub.app/index.php/Subdomains_and_Custom_Domains)