### PR TITLE
Adding silicon-valley subdomain

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3114,3 +3114,17 @@ gps:
   - ttl: 600
     type: CNAME
     value: cname.vercel-dns.com.
+silicon-valley:
+  - ttl: 3600
+    type: CNAME
+    value: cname.vercel-dns.com.
+  - ttl: 3600
+    type: TXT
+    value: v=spf1 include:_spf.google.com ~all
+  - ttl: 3600
+    type: MX
+    values:
+      - exchange: mx1.improvmx.com.
+        preference: 10
+      - exchange: mx2.improvmx.com.
+        preference: 20


### PR DESCRIPTION
<!--
This is a template, please modify it to fit your Pull Request. 

Please pick one option when multiple are presented in brackets.

Please title your PR like this: [Adding/Deleting/Updating] `subdomain.[hackclub.com/dino.icu/etc]`
-->

# [Adding/Deleting/Updating] `subdomain.[hackclub.com/dino.icu/etc]`

## Description

Since this was allowed for [another Counterspell event](https://github.com/hackclub/dns/pull/1358), I am asking for this subdomain for us too. We are Counterspell Silicon Valley, and we'd love to use this subdomain for:
1. Redirecting to our https://counterspell.hackclub.com/silicon-valley page (That's quite long, https://silicon-valley.hackclub.com is much shorter!)
2. We have an ambitious idea for a system where participants can log onto a website to get information about workshops, points earned (yet another ambitious idea), and more. We'd love to host this on here.
3. There is an email service added on this as well. If that isn't allowed, that 100% can be removed.