### PR TITLE
Updating counterspell.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -891,6 +891,9 @@ counterspell:
     type: TXT
     value: v=spf1 include:_spf.google.com ~all
   - ttl: 3600
+    type: TXT
+    value: v=DMARC1; p=none; rua=mailto:dmarc@counterspell.hackclub.com
+  - ttl: 3600
     type: MX
     values:
       - exchange: aspmx.l.google.com.

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -889,10 +889,9 @@ counterspell:
     value: cname.vercel-dns.com.
   - ttl: 3600
     type: TXT
-    value: v=spf1 include:_spf.google.com ~all
-  - ttl: 3600
-    type: TXT
-    value: v=DMARC1\; p=none\; rua=mailto:dmarc@counterspell.hackclub.com
+    values:
+      - v=spf1 include:_spf.google.com ~all
+      - v=DMARC1\; p=none\; rua=mailto:dmarc@counterspell.hackclub.com
   - ttl: 3600
     type: MX
     values:

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -892,7 +892,7 @@ counterspell:
     value: v=spf1 include:_spf.google.com ~all
   - ttl: 3600
     type: TXT
-    value: v=DMARC1; p=none; rua=mailto:dmarc@counterspell.hackclub.com
+    value: v=DMARC1\; p=none\; rua=mailto:dmarc@counterspell.hackclub.com
   - ttl: 3600
     type: MX
     values:


### PR DESCRIPTION
# Updating `counterspell.hackclub.com`

## Description

Using Gmail's "Send mail as" with `<city>@counterspell.hackclub.com` results in sent emails being marked as spam due to failing DMARC. 