### PR TITLE
Adding archives.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3136,3 +3136,7 @@ gps:
   - ttl: 600
     type: CNAME
     value: cname.vercel-dns.com.
+archives:
+  - ttl: 600
+    type: CNAME
+    value: crabby605.github.io.

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2072,6 +2072,10 @@ newcanaanlib:
   ttl: 600
   type: CNAME
   value: cname.vercel-dns.com.
+neko:
+ttl: 600
+type: CNAME
+value: cat-jammers.github.io.
 nigeria:
   ttl: 600
   type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -474,6 +474,10 @@ arcadius:
   - ttl: 1
     type: CNAME
     value: asymmetrical-trout-5k9xmc0r8d2c6cggv0pxu70c.herokudns.com.
+archives:
+  - ttl: 600
+    type: CNAME
+    value: crabby605.github.io.
 archived.guide:
   ttl: 600
   type: CNAME
@@ -3136,7 +3140,3 @@ gps:
   - ttl: 600
     type: CNAME
     value: cname.vercel-dns.com.
-archives:
-  - ttl: 600
-    type: CNAME
-    value: crabby605.github.io.


### PR DESCRIPTION

# Adding `archives.hackclub.com`

## Description

this subdomain will be used for storing all the leader newsletters
