### PR TITLE
Adding contact-helper.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -339,6 +339,7 @@ _vercel:
     - vc-domain-verify=awest.hackclub.com,e6d12d504df9bbb88908
     - vc-domain-verify=philippines.hackclub.com,8ce6b0b9767789ac9e92
     - vc-domain-verify=cascade.hackclub.com,9d7bd97667ee52151183
+    - vc-domain-verify=contact-helper.hackclub.com,ecd049f45e2ad550fd89
 a5fj644skxexxgvvraqrag5ngcaovcny._domainkey:
   ttl: 600
   type: CNAME
@@ -846,6 +847,10 @@ churchill:
     type: CNAME
     value: hackclub-ej5rl3bqj.now.sh.
 cider: 
+  - ttl: 600
+    type: CNAME
+    value: cname.vercel-dns.com.
+contact-helper:
   - ttl: 600
     type: CNAME
     value: cname.vercel-dns.com.


### PR DESCRIPTION
# Adding`contact-helper.hackclub.com`
## Add contact-helper for international poster taskforce
It's a link parser-type tool which allows our airtable to have a button to easily get in touch with Hack Clubbers via their provided Slack ID or email.

Hosted version temp @ https://contact-helper.vercel.app/

Any q's to U07BLJ1MBEE or leow@hackclub.com!