### PR TITLE
Add MX record for runshaw.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2478,6 +2478,10 @@ runshaw:
   - ttl: 600
     type: CNAME
     value: dragon863.hackclub.app.
+  - type: MX
+    values:
+      - exchange: mail.danieldb.uk.
+        preference: 1
 s1._domainkey:
   ttl: 600
   type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2476,8 +2476,14 @@ ru:
     value: cname.vercel-dns.com.
 runshaw:
   - ttl: 600
-    type: CNAME
-    value: dragon863.hackclub.app.
+    type: A
+    value: 37.27.51.34
+  - ttl: 600
+    type: AAAA
+    value: 2a01:4f9:3081:399c::4
+  - ttl: 600
+    type: TXT
+    value: domain-verification=dragon863
   - ttl: 600
     type: MX
     value:

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2478,7 +2478,8 @@ runshaw:
   - ttl: 600
     type: CNAME
     value: dragon863.hackclub.app.
-  - type: MX
+  - ttl: 600
+    type: MX
     values:
       - exchange: mail.danieldb.uk.
         preference: 1

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2480,9 +2480,9 @@ runshaw:
     value: dragon863.hackclub.app.
   - ttl: 600
     type: MX
-    values:
-      - exchange: mail.danieldb.uk.
-        preference: 1
+    value:
+      exchange: mail.danieldb.uk.
+      preference: 1
 s1._domainkey:
   ttl: 600
   type: CNAME


### PR DESCRIPTION
# Updating `runshaw.hackclub.com`

## Description

I'm adding a MX record to forward mail to my mail server for runshaw.hackclub.com. This is because in my hack club, club members cannot sign up to github with their school email addresses so I've set up a mail server to forward to their school ones