### PR TITLE
Create, add MX record for runshaw.dino.icu

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -398,6 +398,13 @@ rr: # Rickroll with a single line of bash
   type: CNAME
   value: cname.vercel-dns.com.
 
+runshaw: # Used for an email alias for for runshaw hack club members (https://runshaw.hackclub.com/) - contact @Dragon863
+  ttl: 600
+  type: MX
+  value:
+    exchange: mail.danieldb.uk.
+    preference: 1
+
 scales: # (yet another?) currency slack bot (with some web UI) :D
   ttl: 600
   type: A


### PR DESCRIPTION
# Adding `runshaw.dino.icu`

## Description

I am creating `runshaw.dino.icu` as an email forwarder for members of [Runshaw Hack Club](http://runshaw.hackclub.com/) so they can sign up for github. I'm using dino.icu because email is not permitted on hackclub.com subdomains