### PR TITLE
Add ahoy.hack.club

### DIFF
--- a/hack.club.yaml
+++ b/hack.club.yaml
@@ -2,6 +2,9 @@
 "":
   - type: ALIAS
     value: solid-daffodil-0mn798giomwnltj8ssbu2xb6.herokudns.com.
+ahoy:
+  - type: CNAME
+    value: cname.vercel-dns.com.
 hack.club:
   - type: ALIAS
     value: cname.vercel-dns.com.


### PR DESCRIPTION
This adds ahoy.hack.club as a short link for highseas.hackclub.com!