### PR TITLE
Added svis.hackclub.com to DNS (hackclub.com.yaml)

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3216,3 +3216,15 @@ portal:
   - ttl: 600
     type: A
     value: 173.255.236.153
+svis:
+  - ttl: 600
+    type: MX
+    value: mx1.improvmx.com.
+    priority: 10
+  - ttl: 600
+    type: MX
+    value: mx2.improvmx.com.
+    priority: 20
+  - ttl: 600
+    type: TXT
+    value: v=spf1 include:spf.improvmx.com ~all


### PR DESCRIPTION
Added svis.hackclub.com DNS with ImprovMX for Email Forwarding.

<!--
This is a template, please modify it to fit your Pull Request. 

Please pick one option when multiple are presented in brackets.

Please title your PR like this: [Adding/Deleting/Updating] `subdomain.[hackclub.com/dino.icu/etc]`
-->

# [Adding/Deleting/Updating] `subdomain.[hackclub.com/dino.icu/etc]`

## Description

Added ImprovMX Email Forwarding credentials to be used by my club of Sri Venkateshwar International School (SVIS in short) Hackclub
