### PR TITLE
Adding italia.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1736,6 +1736,10 @@ it:
   - ttl: 600
     type: CNAME
     value: cname.vercel-dns.com.
+italia:
+  - ttl: 600
+  type: A
+  value: 185.151.30.185
 iter:
   ttl: 600
   type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1736,7 +1736,7 @@ it:
     type: CNAME
     value: cname.vercel-dns.com.
 italia:
-  - ttl: 600
+  ttl: 600
   type: A
   value: 185.151.30.185
 iter:


### PR DESCRIPTION
Adds DNS for newly created club, Italia, based in sicily. Website is work in progress.

adds club subdomain (italia.hackclub.com) that points to 185.151.30.185 (ipv4)
