### PR TITLE
Adding dessert.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1065,6 +1065,10 @@ dedicated.servers:
   - ttl: 600
     type: A
     value: 173.208.140.122
+dessert:
+  - ttl: 600
+    type: CNAME
+    value: dessert-ysws.netlify.app.
 devhacks:
   - ttl: 600
     type: TXT
@@ -3259,7 +3263,3 @@ metabase:
   - ttl: 600
     type: CNAME
     value: naigidt4.up.railway.app.
-dessert:
-  - ttl: 600
-    type: CNAME
-    value: dessert-ysws.netlify.app.


### PR DESCRIPTION
# Adding dessert.hackclub.com

## Description

Adding the Official Dessert YSWS landing page url here. This is for our official YSWS, were you ship an Android app, and get the $25 to buy your google play dev license. Right now it's on netlify, and we want to have it have a .hackclub.com url. Thanks!
