### PR TITLE
Update hackclub.com.yaml

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -778,6 +778,13 @@ calendar:
   ttl: 600
   type: CNAME
   value: ghs.googlehosted.com.
+calhack:
+  - ttl: 600
+    type: CNAME
+    value: cname.vercel-dns.com.
+  - ttl: 600
+    type: CNAME
+    value: cname.vercel-dns.com.  
 camp:
   ttl: 600
   type: CNAME
@@ -3263,7 +3270,4 @@ metabase:
   - ttl: 600
     type: CNAME
     value: naigidt4.up.railway.app.
-calhack:
-  - ttl: 600
-    type: CNAME
-    value: calhack-to-be-updated.vercel.app.
+

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3263,3 +3263,7 @@ metabase:
   - ttl: 600
     type: CNAME
     value: naigidt4.up.railway.app.
+calhack:
+  - ttl: 600
+    type: CNAME
+    value: calhack-to-be-updated.vercel.app.

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -344,6 +344,7 @@ _vercel:
     - vc-domain-verify=capsule.hackclub.com,2095a0d425ab70e65ae2
     - vc-domain-verify=hacky-holidays.hackclub.com,c8f8c52c1790e239650e
     - vc-domain-verify=hackyholidays.hackclub.com,dcb0e995448d8cfaae37
+    - vc-domain-verify=calhack.hackclub.com,a8885ee6eb6667cbf089
 a5fj644skxexxgvvraqrag5ngcaovcny._domainkey:
   ttl: 600
   type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -783,9 +783,6 @@ calhack:
   - ttl: 600
     type: CNAME
     value: cname.vercel-dns.com.
-  - ttl: 600
-    type: CNAME
-    value: cname.vercel-dns.com.  
 camp:
   ttl: 600
   type: CNAME


### PR DESCRIPTION
# Adding calhack.hackclub.com
## Description
This domain will be used for Çatalca Anatollian School's Hack Club https://www.instagram.com/calhackclub/

_Note The site will be updated with next commit._