### PR TITLE
Adding glenny.hackclub.com

### DIFF
--- a/hack.club.yaml
+++ b/hack.club.yaml
@@ -8,6 +8,9 @@ ahoy:
 hack.club:
   - type: ALIAS
     value: cname.vercel-dns.com.
+glenny:
+  - type: CNAME
+    value: bobbedbob.github.io
 l:
   - type: CNAME
     value: developmental-honeysuckle-bw0w1sr07xraztscn4sxtahk.herokudns.com.

--- a/hack.club.yaml
+++ b/hack.club.yaml
@@ -8,9 +8,6 @@ ahoy:
 hack.club:
   - type: ALIAS
     value: cname.vercel-dns.com.
-glenny:
-  - type: CNAME
-    value: bobbedbob.github.io
 l:
   - type: CNAME
     value: developmental-honeysuckle-bw0w1sr07xraztscn4sxtahk.herokudns.com.

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1470,6 +1470,10 @@ github-oauth:
   ttl: 600
   type: CNAME
   value: synthetic-grape-ht3rdj3kqbc6fuyjcuc5f6ob.herokudns.com.
+glenny:
+  - ttl: 600
+    type: CNAME
+    value: bobbedbob.github.io.
 globalcovid:
   ttl: 600
   type: CNAME


### PR DESCRIPTION
# Adding glenny.hack.club

## Description

I am adding glenny.hack.club which points to my Github Pages site currently at ghc.bobbedbob.io.
This is for Glenny Hack Club which is an official Hack Club that will run in 2025 at Glen Waverley Secondary College, Melboburne, Australia.
