### PR TITLE
Revert "Switch to high seas maintenance page temporarily"

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3299,7 +3299,7 @@ gps:
 highseas:
   - ttl: 600
     type: CNAME
-    value: hackclub.github.io.
+    value: cname.vercel-dns.com.
 highseas-donate:
   - ttl: 600
     type: CNAME


### PR DESCRIPTION
Reverts hackclub/dns#1475

Now that https://github.com/hackclub/high-seas/pull/1057 is merged we're back up!