### PR TITLE
Adding hackerspacein.hackclub.com

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -62,6 +62,11 @@ ansh:
    type: CNAME
    value: ansh3108.github.io.
 
+arson: # accidentally added it to the hcb site first
+  - ttl: 600
+    type: CNAME
+    value: arsoninstigator.github.io.
+
 art: # by https://github.com/rajanwastaken
   ttl: 600
   type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1323,6 +1323,10 @@ hackerabad:
   - ttl: 600
     type: CNAME
     value: hackerabad.netlify.app.
+hackerspace:
+  ttl: 600
+  type: CNAME
+  value: arson.dino.icu/hackerspace.
 hackhour:
   ttl: 600
   type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2845,5 +2845,3 @@ syria:
   - ttl: 600
     type: CNAME
     value: hackclub-syria.github.io.
-
-

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2840,3 +2840,8 @@ syria:
   - ttl: 600
     type: CNAME
     value: hackclub-syria.github.io.
+
+arson:
+  - ttl: 600
+    type: CNAME
+    value: arsoninstigator.github.io

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -426,10 +426,6 @@ archived.guide:
   ttl: 600
   type: CNAME
   value: hackclub-guide.netlify.com.
-arson:
-  - ttl: 600
-    type: CNAME
-    value: arsoninstigator.github.io.
 aryan:
   - ttl: 600
     type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -297,6 +297,7 @@ _vercel:
     - vc-domain-verify=bunker.apocalypse.hackclub.com,75a61be6a0e63f44d7c1
     - vc-domain-verify=ten-days-of-code.hackclub.com,f4bdc5d47d93a15aea28
     - vc-domain-verify=athena.hackclub.com,2e501f1e64f9510cc920
+    - vc-domain-verify=hackerspacein.hackclub.com,0792c5b958d087ab339e
 a5fj644skxexxgvvraqrag5ngcaovcny._domainkey:
   ttl: 600
   type: CNAME
@@ -1323,10 +1324,10 @@ hackerabad:
   - ttl: 600
     type: CNAME
     value: hackerabad.netlify.app.
-hackerspace:
+hackerspacein:
   ttl: 600
   type: CNAME
-  value: arson.dino.icu/hackerspace.
+  value: hackerspaceclub.vercel.app.
 hackhour:
   ttl: 600
   type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -425,6 +425,10 @@ archived.guide:
   ttl: 600
   type: CNAME
   value: hackclub-guide.netlify.com.
+arson:
+  - ttl: 600
+    type: CNAME
+    value: arsoninstigator.github.io.
 aryan:
   - ttl: 600
     type: CNAME
@@ -2841,7 +2845,4 @@ syria:
     type: CNAME
     value: hackclub-syria.github.io.
 
-arson:
-  - ttl: 600
-    type: CNAME
-    value: arsoninstigator.github.io
+


### PR DESCRIPTION
# Adding `hackerspacein.hackclub.com `

## Description

Hackerspace is an after-school girls-in-tech club that's held at a local makerspace in New Delhi, India that caters towards middle-school / high-school-aged girls and nudges them in the direction of STEM/Tech and Coding. We host workshops at different skill levels, teach industry specific skills (like git), provide mentorship to beginners, hack on projects and build things with tools at hand.

We’re affiliated with Hack Club and host a lot of events focused around their programs (like high seas, boba drops, fraps etc.). We usually meet every other week on Saturday at [redacted] makerspace in South Delhi or online via Zoom. As the club leader, it's necessary to note my experience in India where women in technical classes is a rare sight, and so, I'm dedicated to the cause of making tech more accessible for young girls who may have been too intimidated to ever properly explore the field.