### PR TITLE
Adding 'hackerspacein.hackclub.com'

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -345,6 +345,7 @@ _vercel:
     - vc-domain-verify=hacky-holidays.hackclub.com,c8f8c52c1790e239650e
     - vc-domain-verify=hackyholidays.hackclub.com,dcb0e995448d8cfaae37
     - vc-domain-verify=dessert.hackclub.com,8452d8879c3995b17783
+    - vc-domain-verify=hackerspacein.hackclub.com,0792c5b958d087ab339e
 a5fj644skxexxgvvraqrag5ngcaovcny._domainkey:
   ttl: 600
   type: CNAME
@@ -1555,6 +1556,10 @@ hackerabad:
   - ttl: 600
     type: CNAME
     value: hackerabad.netlify.app.
+hackerspacein:
+  ttl: 600
+  type: CNAME
+  value: hackerspaceclub.vercel.app.
 hackhour:
   ttl: 600
   type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1559,7 +1559,7 @@ hackerabad:
 hackerspacein:
   ttl: 600
   type: CNAME
-  value: hackerspaceclub.vercel.app.
+  value: cname.vercel-dns.com.
 hackhour:
   ttl: 600
   type: CNAME


### PR DESCRIPTION
# Adding `hackerspacein.hackclub.com`

## Description
Hackerspace is an after-school girls-in-tech club that's held at a local makerspace in New Delhi, India that caters towards middle-school / high-school-aged girls and nudges them in the direction of STEM/Tech and Coding. We host workshops at different skill levels, teach industry specific skills (like git), provide mentorship to beginners, hack on projects and build things with tools at hand.

We’re affiliated with Hack Club and host a lot of events focused around their programs (like high seas, boba drops, fraps etc.). We usually meet every other week on Saturday at [redacted] makerspace in South Delhi or online via Zoom. As the club leader, it's necessary to note my experience in India where women in technical classes is a rare sight, and so, I'm dedicated to the cause of making tech more accessible for young girls who may have been too intimidated to ever properly explore the field.
