### PR TITLE
Adding scrapyardkigali.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3334,3 +3334,7 @@ metabase:
   - ttl: 600
     type: CNAME
     value: a.selfhosted.hackclub.com.
+scrapyardkigali:
+  - ttl: 600
+    type: CNAME
+    value: cname.vercel-dns.com.

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1,5 +1,10 @@
 ---
 "":
+_vercel:
+  - ttl: 600
+    type: TXT
+    value: vc-domain-verify=scrapyardkigali.hackclub.com,67fc1c8234f8f2963acc
+
   - type: ALIAS
     value: cname.vercel-dns.com.
   - ttl: 600
@@ -3334,7 +3339,3 @@ metabase:
   - ttl: 600
     type: CNAME
     value: a.selfhosted.hackclub.com.
-scrapyardkigali:
-  - ttl: 600
-    type: CNAME
-    value: cname.vercel-dns.com.


### PR DESCRIPTION
I added the subdomain scrapyardkigali.hackclub.com with a CNAME record pointing to Vercel

<!--
This is a template, please modify it to fit your Pull Request. 

Please pick one option when multiple are presented in brackets.

Please title your PR like this: [Adding/Deleting/Updating] `sudomain.[hackclub.com/dino.icu/etc]`
-->

# [Adding] `scrapyardkigali.hackclub.com`

## Description

This PR adds the subdomain scrapyardkigali.hackclub.com. We are hosting Scrapyard Kigali, our local version of the global Scrapyard hackathon. Hack Club told us that we would build the website ourselves, so we are asking for this subdomain to point to our site hosted on Vercel.

Additionally, we were provided with a TXT record for domain verification by Vercel:

 - Type: TXT
 - Name: _vercel
![Screenshot 2025-01-04 230116](https://github.com/user-attachments/assets/c239e184-5cfa-420f-b31b-fab4b8a9466a)
- Value: vc-domain-verify=scrapyardkigali.hackclub.com,67fc1c8234f8f2963acc

Thanks in advance for your support! Let us know if any changes are needed.
