### PR TITLE
Update proton.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2465,7 +2465,7 @@ printboard:
 proton:
   ttl: 600
   type: CNAME
-  value: techpro709.github.io.
+  value: pxldevv.github.io.
 proxyparty:
   type: A
   value: 45.79.164.46


### PR DESCRIPTION
Updating to handle GitHub username change

# [Updating] `proton.[hackclub.com]`

## Description

Changing proton.hackclub.com dns from techpro709.github.io to pxldevv.github.io (my new GitHub username)