### PR TITLE
chore(dino.icu): use deSEC nameservers for andreijiroh and ajhalili2006 subdomains

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -54,14 +54,17 @@
 
 ajhalili2006: # by https://github.com/ajhalili2006 via https://github.com/andreijiroh-dev/website
   - ttl: 600
-    type: CNAME
-    # redirects to https://andreijiroh.xyz via caddy config at https://github.com/recaptime-dev/proxyparty-caddy
-    value: proxyparty.recaptime.dev.
+    type: NS
+    values:
+    - ns1.desec.io.
+    - ns2.desec.io.
 
 andreijiroh: # by https://github.com/ajhalili2006, but uses his first name as subdomain instead of github username
   - ttl: 600
-    type: CNAME
-    value: proxyparty.recaptime.dev.
+    type: NS
+    values:
+    - ns1.desec.io.
+    - ns2.desec.io.
 
 avsc:
   ttl: 600


### PR DESCRIPTION
<!--
This is a template, please modify it to fit your Pull Request. 

Please pick one option when multiple are presented in brackets.

Please title your PR like this: [Adding/Deleting/Updating] `subdomain.[hackclub.com/dino.icu/etc]`
-->

# Updating `<ajhalili2006|andreijiroh>.dino.icu`

## Description

Because `dino.icu` currently is not on the [Public Suffix List](https://github.com/publicsuffix/list) which is being used by Cloudflare and friends for validating domain roots for some reason (see https://github.com/publicsuffix/list/wiki/Third-Party-Diffusion for context), I opt to use [deSEC](https://desec.io) nameservers as a workaround, pending domain limit requests (new accounts can add 1 domain by default unless emailed support).

