### PR TITLE
Adding minustwelve.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2122,6 +2122,10 @@ milton:
   ttl: 10000
   type: CNAME
   value: miltonhackclub.pages.dev.
+minustwelve:
+  ttl: 600
+  type: CNAME
+  value: hackclub.github.io.
 miracosta:
   ttl: 600
   type: CNAME


### PR DESCRIPTION
# Adding `minustwelve.hackclub.com`

## Description
Minus Twelve is my new YSWS which will begin this week.\
the page was previously hosted at https://sporeball.dev/minus-twelve and i'd like it to graduate from https://hackclub.github.io/minus-twelve now that the repo has been transferred.