### PR TITLE
Adding podium.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -344,6 +344,7 @@ _vercel:
     - vc-domain-verify=capsule.hackclub.com,2095a0d425ab70e65ae2
     - vc-domain-verify=hacky-holidays.hackclub.com,c8f8c52c1790e239650e
     - vc-domain-verify=hackyholidays.hackclub.com,dcb0e995448d8cfaae37
+    - vc-domain-verify=podium.hackclub.com,8dad6840c48e341ef42e
 a5fj644skxexxgvvraqrag5ngcaovcny._domainkey:
   ttl: 600
   type: CNAME
@@ -2375,6 +2376,10 @@ plis:
   type: CNAME
   value: plis-hackclub.netlify.app.
 podcast:
+  ttl: 600
+  type: CNAME
+  value: cname.vercel-dns.com.
+podium:
   ttl: 600
   type: CNAME
   value: cname.vercel-dns.com.


### PR DESCRIPTION
# Adding `podium.hackclub.com`

## Description

Added subdomain to host a hackathon voting system for the events team. Also added Vercel verification record.

cc @devenjadhav 
