### PR TITLE
Adding berman.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -689,6 +689,10 @@ berkley:
   - ttl: 600
     type: CNAME
     value: ce68625a-92ad-439c-823d-7dc4bab9c62f.repl.co.
+berman:
+   - ttl: 600
+     type: CNAME
+     value: bermanclub.pages.dev
 bewacky:
   - ttl: 600
     type: TXT

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -692,7 +692,7 @@ berkley:
 berman:
    - ttl: 600
      type: CNAME
-     value: bermanclub.pages.dev
+     value: bermanclub.pages.dev.
 bewacky:
   - ttl: 600
     type: TXT


### PR DESCRIPTION
added new subdomain berman.hackclub.com to be used by the new berman hackclub. Currently the page redirects to the club google chat, but its already on cloudflare pages so it will be able to be easily switched to a website once we get that built.
