### PR TITLE
remove dangling cnames & netlify/github takeovers

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2204,10 +2204,6 @@ nmit:
   - ttl: 600
     type: CNAME
     value: cname.vercel-dns.com.
-northpark:
-  - ttl: 600
-    type: CNAME
-    value: nphack.club.
 notebook:
   - ttl: 600
     type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -42,10 +42,6 @@ ihs:
 20230913174421pm._domainkey:
   type: TXT
   value: k=rsa\; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCbYfun+ZMwXJGRqp41sG/OXWPgbQd6Ewf/ccOBCvigm9LSarnT1QCUizzc+ZqBfSc4UTlJJx2hyhWYN6zFHibSndOBmY3y09uKuv7S4v3usfhpVVJZw9BOQLL4N9uIysrzLhVOfCpXiIIQQHn/a277SA8klIDfVcZkxdkyBRQDlQIDAQAB
-3blue1brown:
-  ttl: 600
-  type: CNAME
-  value: 97be9df7-6155-40f3-8f4b-ee2b9dcb811e.repl.co.
 "14148987": # SendGrid Sender Authentication (bank@hackclub.com)
   ttl: 600
   type: CNAME
@@ -568,10 +564,6 @@ assets:
   ttl: 600
   type: CNAME
   value: cname.vercel-dns.com.
-astrohacks:
-  - ttl: 600
-    type: CNAME
-    value: www.mmgraphix.net.
 asw:
   - ttl: 600
     type: A
@@ -595,10 +587,6 @@ australia:
   ttl: 600
   type: CNAME
   value: cname.vercel-dns.com.
-av:
-  - ttl: 600
-    type: CNAME
-    value: avhc.netlify.com.
 awards:
   - ttl: 600
     type: CNAME
@@ -687,10 +675,6 @@ berkeley:
   - ttl: 600
     type: CNAME
     value: berkeleyhackclub.github.io.
-berkley:
-  - ttl: 600
-    type: CNAME
-    value: ce68625a-92ad-439c-823d-7dc4bab9c62f.repl.co.
 berman:
    - ttl: 600
      type: CNAME
@@ -921,10 +905,6 @@ browserbuddy:
   - ttl: 600
     type: CNAME
     value: cname.vercel-dns.com.
-ciudalcampo:
-  - ttl: 600
-    type: CNAME
-    value: code-sekcc.github.io.
 ckag6kd47cfmvkhvvyy4licplz3nlev2._domainkey.conduct-test:
   ttl: 600
   type: CNAME
@@ -937,10 +917,6 @@ codeabit:
   - ttl: 600
     type: CNAME
     value: codeabitkw.github.io.
-coet:
-  - ttl: 600
-    type: CNAME
-    value: hackclubcoet.github.io.
 coins:
   - ttl: 600
     type: A
@@ -1057,10 +1033,6 @@ ctrlalttec:
         preference: 10
       - exchange: alt4.aspmx.l.google.com.
         preference: 10
-cucek:
-  - ttl: 600
-    type: CNAME
-    value: hackclubcucekv4.netlify.app.
 customizer:
   - ttl: 600
     type: CNAME
@@ -1161,10 +1133,6 @@ dinoexplorer:
   - ttl: 600
     type: CNAME
     value: internetramen.github.io.
-dinos:
-  - ttl: 600
-    type: CNAME
-    value: orpheus-dinos.netlify.com.
 dorman:
   ttl: 600
   type: ALIAS
@@ -1334,10 +1302,6 @@ epochvt:
         preference: 10
       - exchange: aspmx4.googlemail.com.
         preference: 10
-eps:
-  ttl: 600
-  type: CNAME
-  value: hceps.noallus.nl.
 events:
   ttl: 600
   type: CNAME
@@ -1496,10 +1460,6 @@ gaynormccown:
         preference: 10
       - exchange: alt4.aspmx.l.google.com.
         preference: 10
-gdynia:
-  - ttl: 600
-    type: CNAME
-    value: nervous-rosalind-a81ecb.netlify.com.
 geochat:
   ttl: 600
   type: CNAME
@@ -1508,10 +1468,6 @@ geochat-api:
   ttl: 600
   type: CNAME
   value: geochat-api.hackclub.com.herokudns.com.
-gharbia:
-  ttl: 600
-  type: CNAME
-  value: hack-club-gh.github.io.
 gita:
   - ttl: 600
     type: A
@@ -2161,10 +2117,6 @@ middleman:
   ttl: 600
   type: CNAME
   value: middleman-hackclub.fly.dev.
-milesmac:
-  ttl: 600
-  type: CNAME
-  value: 7b6d4e2f-ac5b-41f5-ab5e-d3c248bcda0c.repl.co.
 milton:
   ttl: 10000
   type: CNAME
@@ -2212,10 +2164,6 @@ mx._domainkey:
   ttl: 600
   type: TXT
   value: k=rsa\; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC2ne6b1zFQ+JeHfdYOZmfXdPh9oxE8jJ4VYhHKelLyefiYMPC8TUqL/iYy4meTTUcVskryzK6pMB6tIh3+JhgyxacK+dapNcTTd8LOkI0G3d5JX4+5aq99YHi71KGpVREedJeFjnPeNMEBtrRc5Jsb6HFHFxNtH270fchVO+hgRwIDAQAB
-naal:
-  - ttl: 600
-    type: CNAME
-    value: f188f909-4cbb-48f7-8391-1f4096ded524.id.repl.co.
 nairobi:
   - ttl: 600
     type: CNAME
@@ -2395,10 +2343,6 @@ parcel-pyxis:
   - ttl: 600
     type: CNAME
     value: a.selfhosted.hackclub.com.
-petcs:
-  ttl: 600
-  type: CNAME
-  value: exquisite-stroopwafel-98a808.netlify.app.
 philanthropy:
   ttl: 600
   type: CNAME
@@ -2566,10 +2510,6 @@ raspapi:
   - ttl: 600
     type: CNAME
     value: cname.vercel-dns.com.
-ravenhack:
-  - ttl: 600
-    type: CNAME
-    value: ravenhack.org.
 rawr:
   - ttl: 600
     type: CNAME
@@ -2622,10 +2562,6 @@ rrhs:
   - ttl: 600
     type: CNAME
     value: rrhs-hack-club.netlify.app.
-rrhshack:
-  - ttl: 600
-    type: CNAME
-    value: rrhshack.github.io.
 ru:
   - ttl: 600
     type: CNAME
@@ -2663,9 +2599,6 @@ saycheese:
   ttl: 600
   type: CNAME
   value: cname.vercel-dns.com.
-schacks:
-  - type: CNAME
-    value: schacks.netlify.com.
 schedule:
   - type: CNAME
     value: calendso-production-f2a4.up.railway.app.
@@ -2933,10 +2866,6 @@ summer:
         preference: 10
       - exchange: aspmx4.googlemail.com.
         preference: 10
-summitshasta:
-  - ttl: 600
-    type: CNAME
-    value: summitshasta.github.io.
 synthax:
   - ttl: 600
     type: CNAME
@@ -3052,10 +2981,6 @@ tist:
         preference: 10
       - exchange: alt4.aspmx.l.google.com.
         preference: 10
-titanhacks:
-  - ttl: 600
-    type: CNAME
-    value: titanhacks.club.
 tlap:
     ttl: 600
     type: CNAME
@@ -3068,10 +2993,6 @@ toriel:
   - ttl: 600
     type: CNAME
     value: enigmatic-celmentine-ut0w3vatz8vihtqllhcsl1o2.herokudns.com.
-toronto:
-  - ttl: 600
-    type: CNAME
-    value: torontohacks.github.io.
 tr:
   ttl: 600
   type: CNAME
@@ -3116,18 +3037,6 @@ university:
   - ttl: 600
     type: CNAME
     value: developmental-garbanzo-kw68e5tap3bg721c9c295nux.herokudns.com.
-upa:
-  - ttl: 600
-    type: CNAME
-    value: 6f5d91a6-7aa7-49a6-b4ab-2b0111bb11a7.id.repl.co.
-upademo:
-  - ttl: 600
-    type: CNAME
-    value: 2695607c-ab46-45ec-a854-984b419c11df.id.repl.co.
-upalinks:
-  - ttl: 600
-    type: CNAME
-    value: 6f5d91a6-7aa7-49a6-b4ab-2b0111bb11a7.id.repl.co.
 uqq467l64nnf3dyo6omjcjmcc3dmdqlb._domainkey:
   - ttl: 600
     type: CNAME
@@ -3235,11 +3144,6 @@ wggs:
   - ttl: 600
     type: CNAME
     value: luna5379.github.io.
-    
-whis:
-  - ttl: 600
-    type: CNAME
-    value: 10e7a551-01d9-4a6f-916a-c095ba0fe225.id.repl.co.
 
 whs:
   - ttl: 600
@@ -3309,10 +3213,6 @@ zephyr:
   - ttl: 600
     type: CNAME
     value: cname.vercel-dns.com.
-zephyrnet:
-  - ttl: 600
-    type: NS
-    value: hackclub.myftp.biz.
 zguide:
   - ttl: 600
     type: CNAME
@@ -3345,21 +3245,11 @@ hacktks:
   - ttl : 1
     type: CNAME 
     value: cname.vercel-dns.com.
-    
-hupy:
-  - ttl: 600
-    type: CNAME
-    value: hupy.github.io.
 
 codecafe:
 - ttl: 600
   type: CNAME 
   value: cname.vercel-dns.com.
-
-team:
-- ttl: 600
-  type: CNAME
-  value: walrus-app-ynr6x.ondigitalocean.app.
   
 syria:
   - ttl: 600


### PR DESCRIPTION
ahoy dns fellas!
every so often i get an email along the lines of these from various skids running nucleus scans and then hitting security.txt emails in the hopes of getting a free bug bounty:
![CleanShot 2025-01-27 at 12 57 18@2x](https://github.com/user-attachments/assets/a00bbf35-3419-4a08-a2ad-e1a6bbe33eb0)
my internal response is "who cares, pick up a foot ball", but it's annoying, so i took a pass and pruned a bunch of them.
these are all either pointing to things that don't exist anymore or hello world pages from a while ago.

additionally, these people seem to have valid websites getting cnamed to but don't work for some reason? they should probably either remove them or fix:
- busan.hackclub.com
- malagon.hackclub.com
- ntp.hackclub.com
- stemsharkya.hackclub.com
- vikingsdev.hackclub.com
- webstergroves.hackclub.com