### PR TITLE
Redirect hack.af requests to coolify

### DIFF
--- a/hack.af.yaml
+++ b/hack.af.yaml
@@ -1,7 +1,7 @@
 ---
 "":
   - type: ALIAS
-    value: adjacent-crag-9vk67y6ktr6zzlqitcb2fxwn.herokudns.com.
+    value: a.selfhosted.hackclub.com.
   - type: MX
     value:
       exchange: mail.hack.af.


### PR DESCRIPTION
The intention is to move hack.af (and only hack.af - not hack.club yet) requests to Coolify.