### PR TITLE
Remove skyfall.dino.icu high seas client

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -447,11 +447,6 @@ sk: # sk.dino.icu unofficial hackclub sharkey instance
   ttl: 600
   type: CNAME
   value: vic.hackclub.app.
-  
-skyfall: # Skyfall's website (gh: SkyfallWasTaken, email: hackclubdns@skyfall.33mail.com)
-  ttl: 600
-  type: CNAME
-  value: cname.vercel-dns.com.
 
 # spend hq's money
 spend:


### PR DESCRIPTION
This is a temporary change to handle a client that's accidentally generating a lot of requests to airtable during the end of high seas https://hackclub.slack.com/archives/C07PZMBUNDS/p1738476907877469