### PR TITLE
[Adding] `printlegion.hackclub.com`

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2525,6 +2525,10 @@ printboard:
   - ttl: 600
     type: CNAME
     value: cname.vercel-dns.com.
+printlegion:
+  - ttl: 600
+    type: CNAME
+    value: a.selfhosted.hackclub.com.
 proton:
   ttl: 600
   type: CNAME


### PR DESCRIPTION

# [Adding] `printlegion.hackclub.com`

## Description
DNS for hack club's print legion, a distributed printing network for YSWSes
