### PR TITLE
Switch api2 to coolify

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -389,7 +389,7 @@ astra:
 airbridge:
   ttl: 600
   type: CNAME
-  value: radiant-fox-c9gxih2agg56l8y9b5tefjm2.herokudns.com.
+  value: a.selfhosted.hackclub.com.
 aloha:
   - ttl: 600
     type: CNAME
@@ -488,7 +488,7 @@ api:
 api2:
   ttl: 600
   type: CNAME
-  value: tetrahedral-gooseberry-aady3np0p0xldlvl6d7ik0ld.herokudns.com.
+  value: a.selfhosted.hackclub.com.
 api.ctrl-alt-tec:
   - ttl: 600
     type: CNAME


### PR DESCRIPTION
This brings api2.hackclub.com & airbridge.hackclub.com to self-hosting!