### PR TITLE
Switch `hcb-test.hackclub.com` to Heroku for practice migration

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1753,7 +1753,7 @@ hcb:
     value: google-gws-recovery-domain-verification=49632973
 hcb-test:
   - type: CNAME
-    value: ingress.hcb.hackclub.com.
+    value: integrative-persimmon-bbqibbb7mpgnchg1aiz44ujm.herokudns.com.
 hcb-og:
   type: CNAME
   value: cname.vercel-dns.com.


### PR DESCRIPTION
Switching `hcb-test.hackclub.com` from Coolify to Heroku so that I can practice doing a switch from Heroku -> Coolify and monitor for potential downtime.