### PR TITLE
Edit `hcb-test.hackclub.com` from ALIAS to CNAME

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1752,7 +1752,7 @@ hcb:
     type: TXT
     value: google-gws-recovery-domain-verification=49632973
 hcb-test:
-  - type: ALIAS
+  - type: CNAME
     ttl: 1
     value: integrative-persimmon-bbqibbb7mpgnchg1aiz44ujm.herokudns.com.
 hcb-og:


### PR DESCRIPTION
I guess OctoDNS isn't happy with the alias??
