### PR TITLE
Revert "Switch `hcb.hackclub.com` to Coolify! (#1556)"

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1737,7 +1737,7 @@ key3._domainkey.hcarc:
       
 hcb:
   - type: ALIAS
-    value: ingress.hcb.hackclub.com.
+    value: rocky-jackfruit-11wv1arsenhczo2z58bae8lt.herokudns.com.
     ttl: 300
   - type: MX
     ttl: 6000


### PR DESCRIPTION
This reverts commit 4d7a363a2b603f9905020df271ab62cbfa50d18f.

Bringing HCB back to Heroku to allow us to deploy without downtime (Coolify doesn't support rolling deploys with our setup).

This is temporary as we find a long-term solution.