### PR TITLE
Adding suceava.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2949,6 +2949,10 @@ strong1._domainkey:
 strong2._domainkey:
   type: CNAME
   value: strong2._domainkey.helpscout.net.
+suceava:
+  - ttl: 600
+    type: CNAME
+    value: cname.vercel-dns.com.
 summer:
   - ttl: 600
     type: ALIAS
@@ -3462,8 +3466,3 @@ ai:
   - ttl: 600
     type: A
     value: 5.161.100.52
-    
-suceava:
-  - ttl: 600
-    type: CNAME
-    value: cname.vercel-dns.com.

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -369,6 +369,7 @@ _vercel:
     - vc-domain-verify=hackatsst.hackclub.com,984d9d75559c592d5b88
     - vc-domain-verify=jua.hackclub.com,f187c5e6c1e4e681fb22
     - vc-domain-verify=vidisha.hackclub.com,865c18c50e3614795dfc
+    - vc-domain-verify=suceava.hackclub.com,b3c8f92fe1ba1f1f89f4
 a5fj644skxexxgvvraqrag5ngcaovcny._domainkey:
   ttl: 600
   type: CNAME
@@ -3461,3 +3462,8 @@ ai:
   - ttl: 600
     type: A
     value: 5.161.100.52
+    
+suceava:
+  - ttl: 600
+    type: CNAME
+    value: cname.vercel-dns.com.


### PR DESCRIPTION
Adding suceava.hackclub.com. Will be used for the club's website, where we present our club, present projects, make submission forms for registration, etc.