### PR TITLE
Added HackTV

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -200,6 +200,11 @@ geta: # yoda - https://getadinoicu.yodacode.repl.co/dino.png - get a dino from h
   type: CNAME
   value: ef35bb48-f121-4f7f-91f6-93f601559c24.id.repl.co.
 
+hacktv:
+  - ttl: 600
+    type: CNAME
+    value: conversafe.hackclub.app.
+
 hasd: # hasd school forum
   ttl: 600
   type: A

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3482,7 +3482,3 @@ ai:
   - ttl: 600
     type: A
     value: 5.161.100.52
-hacktv:
-  - ttl: 600
-    type: CNAME
-    value: conversafe.hackclub.app.

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3470,3 +3470,7 @@ ai:
   - ttl: 600
     type: A
     value: 5.161.100.52
+hacktv:
+  - ttl: 600
+    type: CNAME
+    value: conversafe.hackclub.app.


### PR DESCRIPTION
Added a streaming/media service for Hackclub called HackTV

<!--
This is a template, please modify it to fit your Pull Request. 

Please pick one option when multiple are presented in brackets.

Please title your PR like this: [Adding/Deleting/Updating] `subdomain.[hackclub.com/dino.icu/etc]`
-->

# Adding `hacktv.dino.icu`

## Description

This is a media streaming website for hackclub, currently its using my nest server [conversafe.hackclub.app](conversafe.hackclub.app) , but would be great if we could get a better subdomain(Conversafe is an old project of mine) (Its a team project!). The website is open-source and a WIP, but available [here](https://github.com/TalenMud/HackTV) .  The idea is that hackclubbers would display their projects/ upload tutorials there, or if they want they can do live streams too(currently using WebRTC)
Thanks!