### PR TITLE
Add more clear documentation about what to do when you're removing a CNAME and putting other records

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ If you're asked to make any changes to your pull request, please amend it by com
 
 The CNAME record cannot coexist with other record types, which may require you to change to an `ALIAS` or `A` record type if you need additional DNS records on your subdomain. Due to a bug in OctoDNS, removing a CNAME may result in deploying your changes breaking. You might encounter this when trying to use both Vercel and email/Google Workspace on the same subdomain. 
 
-To fix this, follow these steps (each in a seperate PR, `irvine.hackclub.com` is an example of this process):
+To fix this, follow these steps, each in a seperate PR:
 
-1. Make a PR that deletes all records on your subdomain.
-2. Make another PR that adds the additional records needed, replacing the `CNAME` with the other record that you want (oftentimes `ALIAS`).
+1. Make a PR that deletes all records on your subdomain (ex: [#1642](https://github.com/hackclub/dns/pull/1642)).
+2. Make another PR that adds the additional records needed, replacing the `CNAME` with the other record that you want (oftentimes `ALIAS`) (ex: [#1643](https://github.com/hackclub/dns/pull/1643)).
 3. Make it clear to the person reviewing your PRs that the first PR must be merged before the second one. 
 
 ## Limitations

--- a/README.md
+++ b/README.md
@@ -25,13 +25,15 @@ That's it! Someone with contributor access to the repo will then review your PR.
 
 If you're asked to make any changes to your pull request, please amend it by commiting to your fork, instead of closing it and creating another.
 
-### Google Workspace / Vercel Combination
+### Replacing a `CNAME` record with another record type
 
-If you're looking to use both Google Workspace and Vercel, deploying your changes may break. To fix this, follow these steps (each in a seperate step, `irvine.hackclub.com` is an example of this process):
+The CNAME record cannot coexist with other record types, which may require you to change to an `ALIAS` or `A` record type if you need additional DNS records on your subdomain. Due to a bug in OctoDNS, removing a CNAME may result in deploying your changes breaking. You might encounter this when trying to use both Vercel and email/Google Workspace on the same subdomain. 
 
-1. Delete all records associated to your subdomain.
-2. Add the records needed for Google Workspace to your subdomain.
-3. Add the remaining records you'd like for your subdomain. Instead of a `CNAME`, use `ALIAS`.
+To fix this, follow these steps (each in a seperate PR, `irvine.hackclub.com` is an example of this process):
+
+1. Make a PR that deletes all records on your subdomain.
+2. Make another PR that adds the additional records needed, replacing the `CNAME` with the other record that you want (oftentimes `ALIAS`).
+3. Make it clear to the person reviewing your PRs that the first PR must be merged before the second one. 
 
 ## Limitations
 


### PR DESCRIPTION
Theres a bug with OctoDNS, where if you edit a file to remove a CNAME record and replace it with something else, it will fail to deploy.

To do it properly, you need to first make a PR that deletes all records, then make a second record which adds your records back another record in place of the CNAME. 

A lot of people were affected by this, so I edited the README to clarify a procedure on how to do this