### PR TITLE
[Updating] `scriptingnest.hackclub.com`

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2865,7 +2865,7 @@ scrapyard:
 scriptingnest:
   - ttl: 600
     type: TXT
-    value: domain-verification=future-x
+    value: domain-verification=yousseftech
   - ttl: 600
     type: A
     value: 37.27.51.34


### PR DESCRIPTION


# [Updating] `scriptingnest.hackclub.com`

## Description

Changed NEST txt verification to club leader username because he had issues with Nest now it is working properly for him