### PR TITLE
Change saif.dino.icu to nameservers

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -453,8 +453,12 @@ runshaw: # Used for an email alias for for runshaw hack club members (https://ru
 
 saif:
   - ttl: 600
-    type: A
-    value: 76.76.21.21
+    type: NS
+    value: ns1.vercel-dns.com
+  - ttl: 600
+    type: NS
+    value: ns2.vercel-dns.com
+
     
 sayhan: # portfolio and other apps?
   - ttl: 600


### PR DESCRIPTION
## Description
Changed saif.dino.icu to nameserver to manage it using vercel.

![image](https://github.com/user-attachments/assets/dbda765a-a75b-469b-a681-d77eae0ffd18)

![image](https://github.com/user-attachments/assets/88669d52-533b-45f9-a3c8-fbc519be973b)

