### PR TITLE
Adding hacklet.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1720,6 +1720,10 @@ hackinux:
   ttl: 600
   type: CNAME
   value: cname.vercel-dns.com.
+hacklet:
+  ttl: 600
+  type: CNAME
+  value: scaling-carnival-4jg9ye4.pages.github.io
 hackpad:
   ttl: 600
   type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1723,7 +1723,7 @@ hackinux:
 hacklet:
   ttl: 600
   type: CNAME
-  value: scaling-carnival-4jg9ye4.pages.github.io
+  value: scaling-carnival-4jg9ye4.pages.github.io.
 hackpad:
   ttl: 600
   type: CNAME


### PR DESCRIPTION
# Adding hacklet.hackclub.com

## Description

This subdomain will be used for the Hacklet YSWS project.
