### PR TITLE
Add status endpoint for hackatime status checker

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1689,6 +1689,10 @@ hackatime-badge:
   - ttl: 600
     type: CNAME
     value: cname.vercel-dns.com.
+status.hackatime:
+  - ttl: 600
+    type: CNAME
+    value: a.selfhosted.hackclub.com.
 hackatsst:
   - ttl: 600
     type: CNAME


### PR DESCRIPTION
This adds a coolify-hosted status checker page for hackatime!