### PR TITLE
Adding `shammah.dino.icu` subdomain

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -495,6 +495,11 @@ shadow: # shadow.dino.icu - contact @justhypex on discord for issues/enquiries
   - exchange: mail.vortex.skyfall.dev.
     preference: 500
 
+shammah: # by https://github.com/Gijutsu-T
+  - ttl: 600
+    type: CNAME
+    value: cname.vercel-dns.com.
+
 short: # short.dino.icu; by kunal botla (.com)
   ttl: 600
   type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -425,6 +425,7 @@ _vercel:
     - vc-domain-verify=waveband.hackclub.com,11dbb017182f655585ef
     - vc-domain-verify=hackatime-badge.hackclub.com,60373d0b6c8c20a2bf7f
     - vc-domain-verify=aurora.hackclub.com,3cb95c1035e0a176fb7a
+    - vc-domain-verify=shammah.hackclub.com,b6aff5ed962bd5632f29
 a5fj644skxexxgvvraqrag5ngcaovcny._domainkey:
   ttl: 600
   type: CNAME
@@ -2951,10 +2952,10 @@ sgd._domainkey: # SendGrid Sender Authentication (bank@hackclub.com)
   ttl: 600
   type: CNAME
   value: sgd.domainkey.u14148987.wl238.sendgrid.net.
-  shammah:
+shammah:
   - ttl: 600
     type: CNAME
-    value: shammahspage.vercel.app.
+    value: cname.vercel-dns.com.
 shipwrecked:
   - ttl: 600
     type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2951,6 +2951,10 @@ sgd._domainkey: # SendGrid Sender Authentication (bank@hackclub.com)
   ttl: 600
   type: CNAME
   value: sgd.domainkey.u14148987.wl238.sendgrid.net.
+  shammah:
+  - ttl: 600
+    type: CNAME
+    value: shammahspage.vercel.app.
 shipwrecked:
   - ttl: 600
     type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -425,7 +425,6 @@ _vercel:
     - vc-domain-verify=waveband.hackclub.com,11dbb017182f655585ef
     - vc-domain-verify=hackatime-badge.hackclub.com,60373d0b6c8c20a2bf7f
     - vc-domain-verify=aurora.hackclub.com,3cb95c1035e0a176fb7a
-    - vc-domain-verify=shammah.hackclub.com,b6aff5ed962bd5632f29
 a5fj644skxexxgvvraqrag5ngcaovcny._domainkey:
   ttl: 600
   type: CNAME
@@ -2952,10 +2951,6 @@ sgd._domainkey: # SendGrid Sender Authentication (bank@hackclub.com)
   ttl: 600
   type: CNAME
   value: sgd.domainkey.u14148987.wl238.sendgrid.net.
-shammah:
-  - ttl: 600
-    type: CNAME
-    value: cname.vercel-dns.com.
 shipwrecked:
   - ttl: 600
     type: CNAME


### PR DESCRIPTION
# Adding `shammah.dino.icu` subdomain

This commit adds the `shammah.dino.icu` subdomain to the DNS configuration file. The subdomain is configured to point to Vercel's default DNS handler at `cname.vercel-dns.com.` It will host the user's personal website deployed on Vercel. I had initially tried to have it on `shammah.hackclub.com` but since it's a personal site, I've moved it.

The following change was made in the `dino.icu.yaml` file:
- Added a CNAME record for `shammah` pointing to `cname.vercel-dns.com.` with a TTL of 600.