### PR TITLE
Update hackclub.com.yaml

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -837,6 +837,10 @@ brasil:
   ttl: 600
   type: CNAME
   value: hack-club-brasil.netlify.app.
+bridgeportoh:
+  - ttl: 600
+    type: TXT
+    value: google-site-verification=uGmPiY3y-za6GGGV4qONYU1fdZD2sTHmZ6M5u6boiAk
 bucky:
   - ttl: 600
     type: CNAME


### PR DESCRIPTION
Adding a new subdomain bridgeportoh.hackclub.com with a TXT record to verify the domain for use with Google Sites. This subdomain will be used to host a club website for Bridgeport High School through Google Sites.