### PR TITLE
Update hackclub.com.yaml

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -837,6 +837,14 @@ brasil:
   ttl: 600
   type: CNAME
   value: hack-club-brasil.netlify.app.
+bridgeportoh:
+  - ttl: 600
+    type: CNAME
+    value: ghs.googlehosted.com.
+
+  - ttl: 600
+    type: TXT
+    value: google-site-verification=uGmPiY3y-za6GGGV4qONYU1fdZD2sTHmZ6M5u6boiAk
 bucky:
   - ttl: 600
     type: CNAME


### PR DESCRIPTION
Adding the subdomain bridgeportoh.hackclub.com for use with a Google Site.
This PR includes:

- A CNAME record pointing to ghs.googlehosted.com. to connect the domain to the site.

- A TXT record for Google Site verification: google-site-verification=uGmPiY3y-za6GGGV4qONYU1fdZD2sTHmZ6M5u6boiAk

This subdomain will serve as the website for the Bridgeport High School Hack Club.