### PR TITLE
Update hackclub.com.yaml

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -837,6 +837,15 @@ brasil:
   ttl: 600
   type: CNAME
   value: hack-club-brasil.netlify.app.
+bridgeportoh:
+  - ttl: 600
+    type: ALIAS
+    value: ghs.googlehosted.com.
+
+  - ttl: 600
+    type: TXT
+    value: google-site-verification=uGmPiY3y-za6GGGV4qONYU1fdZD2sTHmZ6M5u6boiAk
+
 bucky:
   - ttl: 600
     type: CNAME


### PR DESCRIPTION
Adding the subdomain bridgeportoh.hackclub.com for use with a Google Site.

This PR includes:
An ALIAS record pointing to ghs.googlehosted.com. (used instead of CNAME due to root domain restrictions)
A TXT record for Google Site verification:
google-site-verification=uGmPiY3y-za6GGGV4qONYU1fdZD2sTHmZ6M5u6boiAk

This subdomain will host the Bridgeport High School Hack Club site.

