### PR TITLE
Adding hackarest.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1679,14 +1679,14 @@ hackapet:
   - ttl: 600
     type: CNAME
     value: cname.vercel-dns.com.
-hackaruto:
-  - ttl: 600
-    type: CNAME
-    value: hackaruto.netlify.app.
 hackarest:
   - ttl: 600
     type: A
     value: 86.124.168.69
+hackaruto:
+  - ttl: 600
+    type: CNAME
+    value: hackaruto.netlify.app.
 hackathon:
   - ttl: 600
     type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1683,6 +1683,10 @@ hackaruto:
   - ttl: 600
     type: CNAME
     value: hackaruto.netlify.app.
+hackarest:
+  - ttl: 600
+    type: A
+    value: 86.124.168.69.
 hackathon:
   - ttl: 600
     type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1686,7 +1686,7 @@ hackaruto:
 hackarest:
   - ttl: 600
     type: A
-    value: 86.124.168.69.
+    value: 86.124.168.69
 hackathon:
   - ttl: 600
     type: CNAME


### PR DESCRIPTION
# Adding `hackarest.hackclub.com`

## Description

Hackarest is a Hack Club organized in Bucharest. My co-organizer and I intend to use this subdomain as a 'placeholder' while we gather the money for a more permanent one.
