### PR TITLE
Update hackclub.com.yaml

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1450,6 +1450,10 @@ fa:
   - ttl: 1
     type: CNAME
     value: cname.vercel-dns.com.
+feature-tracker:
+  - ttl: 600
+    type: CNAME
+    value: cloudwaddie.hackclub.app.
 feed.assemble:
   - ttl: 600
     type: CNAME


### PR DESCRIPTION
This pull request adds a new DNS record to the `hackclub.com.yaml` configuration file. The change introduces a `feature-tracker` entry with a `CNAME` record pointing to `cloudwaddie.hackclub.app.`.

* [`hackclub.com.yaml`](diffhunk://#diff-5696979ad32f2f8f13cf558f019b36a674a854fba1aa23890a5a1dec51c387fbR1453-R1456): Added a `feature-tracker` entry with a `CNAME` record, a TTL of 600, and a value of `cloudwaddie.hackclub.app.`