### PR TITLE
Update dino.icu.yaml

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -214,6 +214,11 @@ factorio: # factorio.dino.icu - Hack Club hacktorio server - Slack: #factorio
   ttl: 600
   type: A
   value: 168.119.243.45
+  
+featuretracker:
+  ttl: 600
+  type: CNAME
+  value: cloudwaddie.hackclub.app.
 
 firepi:
 - ttl: 600


### PR DESCRIPTION
This pull request introduces a new DNS record and makes a minor modification to an existing record in the `dino.icu.yaml` file.

### DNS Changes:
* Added a new `CNAME` record for `featuretracker` pointing to `cloudwaddie.hackclub.app.` with a TTL of 600.