### PR TITLE
Remove fhsprogramming.hackclub.com, add fhs.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1453,10 +1453,10 @@ feed.assemble:
   - ttl: 600
     type: CNAME
     value: cname.vercel-dns.com.
-fhshackclub:
+fhs:
   - ttl: 600
     type: CNAME
-    value: www.fhsprogramming.com.
+    value: cname.vercel-dns.com.
 finder:
   ttl: 600
   type: CNAME


### PR DESCRIPTION
# Adding fhs.hackclub.com
Adding in the site for the [Fremont High School](https://fhs.fuhsd.org/) Hack Club 

# Removing fhsprogramming.hackclub.com
This club hasn't existed for a while, removing it to reduce ambiguity (hasn't been active in a long time

## Description
Will be used for the FHS Hack Club