### PR TITLE
Add A records for bridgeportohio.com root domain support

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -836,9 +836,22 @@ brasil:
   type: CNAME
   value: hack-club-brasil.netlify.app.
 bridgeportohio:
-  ttl: 600
-  type: TXT
-  value: google-site-verification=LyMzKLL_ipFXkYsFq72ycj_fTyHa9A_KY6_-JdmhQxM
+  records:
+    - ttl: 600
+      type: TXT
+      value: google-site-verification=LyMzKLL_ipFXkYsFq72ycj_fTyHa9A_KY6_-JdmhQxM
+    - ttl: 600
+      type: A
+      value: 216.239.32.21
+    - ttl: 600
+      type: A
+      value: 216.239.34.21
+    - ttl: 600
+      type: A
+      value: 216.239.36.21
+    - ttl: 600
+      type: A
+      value: 216.239.38.21
 www.bridgeportohio:
   ttl: 600
   type: CNAME


### PR DESCRIPTION
This adds four A records to the bridgeportohio.com entry to support root domain access. These point to Google's IPs for domain forwarding, so the non-www version of the site (bridgeportohio.com) will now work alongside www.bridgeportohio.com.