### PR TITLE
Add DNS records for bridgeportohio domain verification and hosting

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -836,9 +836,22 @@ brasil:
   type: CNAME
   value: hack-club-brasil.netlify.app.
 bridgeportohio:
-  ttl: 600
-  type: TXT
-  value: google-site-verification=LyMzKLL_ipFXkYsFq72ycj_fTyHa9A_KY6_-JdmhQxM
+  records:
+    - ttl: 600
+      type: TXT
+      value: google-site-verification=LyMzKLL_ipFXkYsFq72ycj_fTyHa9A_KY6_-JdmhQxM
+    - ttl: 600
+      type: A
+      value: 216.239.32.21
+    - ttl: 600
+      type: A
+      value: 216.239.34.21
+    - ttl: 600
+      type: A
+      value: 216.239.36.21
+    - ttl: 600
+      type: A
+      value: 216.239.38.21
 www.bridgeportohio:
   ttl: 600
   type: CNAME


### PR DESCRIPTION
This PR updates the DNS config for the bridgeportohio domain:

- Adds TXT record for Google site verification  
- Adds A records pointing root domain to Google’s IPs  
- Adds CNAME record for www subdomain to ghs.googlehosted.com

This setup ensures the domain is verified and properly directs traffic to Google hosting.
