### PR TITLE
Add DNS records for Google Site verification and non-www subdomain setup

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -843,6 +843,14 @@ www.bridgeportohio:
   ttl: 600
   type: CNAME
   value: ghs.googlehosted.com.
+www.bridgeportohio:
+  ttl: 600
+  type: TXT
+  value: google-site-verification=LyMzKLL_ipFXkYsFq72ycj_fTyHa9A_KY6_-JdmhQxM
+bridgeportohio:
+  ttl: 600
+  type: CNAME
+  value: ghs.googlehosted.com.
 bucky:
   - ttl: 600
     type: CNAME


### PR DESCRIPTION
Add DNS records for Google Site verification and non-www subdomain setup