### PR TITLE
Add CNAME for nepal.hackclub.com to point to Hack Club Nepal GitHub Pages

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2336,6 +2336,10 @@ ncssm:
   - ttl: 600
     type: CNAME
     value: cname.vercel-dns.com.
+nepal:
+  ttl: 600
+  type: CNAME
+  value: dikshantpandey-dev.github.io.
 nestm:
   ttl: 600
   type: CNAME


### PR DESCRIPTION
### Description:
This PR adds a CNAME record for the nepal.hackclub.com subdomain, pointing it to the Hack Club Nepal GitHub Pages site.

Purpose:
- To launch the official website for Hack Club Nepal using GitHub Pages.
- To provide a custom subdomain under hackclub.com for our club’s activities and resources.