### PR TITLE
Revert "hc organizer"

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2439,9 +2439,19 @@ orpheuspico:
 
 organizer:
   - ttl: 600
-    type: CNAME
-    value: cname.vercel-dns.com.
-    
+    type: TXT
+    values:
+      - canva-domain-verify=28b161e7-222d-4cd8-82d8-0f1177114c8d
+  - ttl: 600
+    type: A
+    values:
+      - 103.169.142.0
+
+www.organizer:
+  - ttl: 600
+    type: A
+    value: 103.169.142.0
+      
 osca:
   - ttl: 600
     type: CNAME


### PR DESCRIPTION
Reverts hackclub/dns#1766

Once again, due to the CNAME bug