### PR TITLE
Add avijitsingh subdomain to hackclub.com DNS

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3702,3 +3702,7 @@ doomscrolling:
   - ttl: 600
     type: CNAME
     value: cname.vercel-dns.com.
+avijitsingh:
+  - ttl: 600
+    type: CNAME
+    value: avijitsingh.ct.ws.


### PR DESCRIPTION
### PR Description

**Add `avijitsingh` subdomain to hackclub.com DNS**

This pull request adds a new subdomain `avijitsingh.hackclub.com` to the DNS configuration . It points the subdomain to `avijitsingh.ct.ws.` as a CNAME record with a TTL of 600 seconds.

This is my first contribution to this repository. Please let me know if any changes are needed!

Thank you for reviewing!
