### PR TITLE
Adding `wallpapers.hackclub.com`

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -404,6 +404,7 @@ _vercel:
     - vc-domain-verify=fhs.hackclub.com,46936764d6774efee2b5
     - vc-domain-verify=passport.hackclub.com,e2df763ae803aaf06728
     - vc-domain-verify=pfp.hackclub.com,0089a080527af2869592
+    - vc-domain-verify=wallpapers.hackclub.com,3ab9c6d22029907f5c6f
 a5fj644skxexxgvvraqrag5ngcaovcny._domainkey:
   ttl: 600
   type: CNAME
@@ -3471,6 +3472,10 @@ waka:
   - ttl: 600
     type: CNAME
     value: a.selfhosted.hackclub.com.
+wallpapers:
+  - ttl: 600
+    type: CNAME
+    value: cname.vercel-dns.com.
 warsaw:
   - ttl: 600
     type: CNAME


### PR DESCRIPTION
# [Adding] `wallpapers.hackclub.com`

## Description

I made a wallpaper app, which uses only wallpapers made by HackClubbers in #background-per-day on Slack. I build the App in NextJS and Electron, so it could be seen from the web. This is an advantage, especailly for mobile users, since they can download the mobile app and set it themself. 
Since it is a Wallpaper App from Hackclubbers, I thought, it will be great, to have it on a HackClub domain. 

This is my Github: [https://github.com/[Lumethra/HC-Wallpaper-App](https://github.com/Lumethra/HC-Wallpaper-App)
This is my web app on vercel: [https://hc-wallpaper-app.vercel.app/](https://hc-wallpaper-app.vercel.app/)

![Screenshot 2025-06-01 174028](https://github.com/user-attachments/assets/0f7618f4-9f60-4a80-81b6-dcb3009c5272)
![Screenshot 2025-06-01 174033](https://github.com/user-attachments/assets/904d9636-4365-4f8b-97d6-d55fedd1df9b)
![Screenshot 2025-06-01 174038](https://github.com/user-attachments/assets/78fd1edc-bd58-46eb-a9b5-0ab4c9a084ab)
![Screenshot 2025-06-01 174048](https://github.com/user-attachments/assets/6b90119a-1c1b-4e18-bfc2-22aa7215b1b1)
![Screenshot 2025-06-01 174058](https://github.com/user-attachments/assets/a1d0544f-3ba0-441f-8daa-d87d2589bcca)
![Screenshot 2025-06-01 174021](https://github.com/user-attachments/assets/5435399c-6a37-4925-b97a-e3ab819cb3a7)
![Screenshot 2025-06-01 174103](https://github.com/user-attachments/assets/13e52160-d50f-45f5-9a75-596edf795994)
https://github.com/user-attachments/assets/f78be4a5-ec07-4b1d-8ca8-569b16f421a6
