### PR TITLE
Update hackclub.com.yaml

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1127,6 +1127,10 @@ coxmill:
   - ttl: 600
     type: CNAME
     value: modest-swanson-0a9aa6.netlify.app.
+crm.stemegypt:
+  - ttl: 600
+    type: CNAME
+    value: stemegypt-crm.42web.io.
 craft:
   - ttl: 600
     type: CNAME


### PR DESCRIPTION
# Adding `crm.stemegypt.hackclub.com`
## Description
This pull request adds the subdomain `crm.stemegypt.hackclub.com.`

It will be used solely to host a WordPress instance for setting up and managing email campaigns using the FluentCRM plugin. This WordPress site is hosted on InfinityFree at `stemegypt-crm.42web.io`, and will integrate with Amazon SES to send emails.

🔒 This subdomain is not connected to our official website at stemegypt.hackclub.com, and is only used for mailing purposes.

Thanks!