### PR TITLE
Add Google Site verification to DNS for Bank Android Developer acct.

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -29,6 +29,7 @@
       - google-site-verification=n9knjT30SgPd80zLKBD6M8fPFGIQUAO5OgfjDsPSrRM
       - google-site-verification=4xlGOIPHkhZqsYh8OMKQy3aqLj6_EKJFAE_iQjb0D_s
       - google-site-verification=xH7iz1qe6HUsWmnYaT9Mxam5K5VhNubX4B-Nl2jmLEw
+      - google-site-verification=dhp4vP1rvcNOr7sHbOF2ynnskqussnxTyxy-xI9edRo
       - v=spf1 include:_spf.google.com include:mailgun.org include:amazonses.com include:sendgrid.net include:spf.mtasv.net ~all
       - stripe-verification=5bdd0e2475b12744bfe1f778ac419f917800d476fd498ae2682ecd161d162c64
       - airtable-verification=6a190bbac6305fe1d58071f48f535cf5


### PR DESCRIPTION
# [Updating] `hackclub.com`

## Description

[Add Google Site verification to DNS for Bank Android Developer acct.](https://github.com/hackclub/dns/commit/62882d0e5a71467202b3f3c3b6be5376a4a13f0b)
