### PR TITLE
Adding plunge.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2735,6 +2735,10 @@ plis:
   ttl: 600
   type: CNAME
   value: plis-hackclub.netlify.app.
+plunge:
+    - ttl: 600
+    type: CNAME
+    value: dandililacs.github.io.
 podcast:
   ttl: 600
   type: CNAME


### PR DESCRIPTION
<!--
Adding plunge.hackclub.com
-->

# Adding plunge.hackclub.com

## This is a subdomain for a BakeBuild V2 YSWS, where students can make plunger cookie cutters with springs and more precision needed.


