### PR TITLE
adding odyssey.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2587,6 +2587,11 @@ ocsa:
     type: ALIAS
     value: cname.vercel-dns.com.
 
+odyssey:
+  - ttl: 600
+    type: CNAME
+    value: cname.vercel-dns.com.
+
 orpheus-engine:
   - type: CNAME
     value: warehouse.selfhosted.hackclub.com.


### PR DESCRIPTION
adding a subdomain for odyssey, the upcoming athena event in los angeles (scheduled for the end of august)
