### PR TITLE
temporarily comment out ajhalili2006 and andreijiroh DNS records for dino.icu as workaround

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -58,16 +58,16 @@ ai:                       # Suprised no one took this yet!
    value: e.hackclub.app. # > the internet except everything is and was vibe coded 
 
 
-ajhalili2006: # by https://github.com/ajhalili2006 via https://github.com/andreijiroh-dev/website
-  - ttl: 600
-    type: CNAME
-    # redirects to https://andreijiroh.xyz via caddy config at https://github.com/recaptime-dev/proxyparty-caddy
-    value: proxyparty.recaptime.dev.
+#ajhalili2006: # by https://github.com/ajhalili2006 via https://github.com/andreijiroh-dev/website
+#  - ttl: 600
+#    type: CNAME
+#    # redirects to https://andreijiroh.xyz via caddy config at https://github.com/recaptime-dev/proxyparty-caddy
+#    value: proxyparty.recaptime.dev.
 
-andreijiroh: # by https://github.com/ajhalili2006, but uses his first name as subdomain instead of github username
-  - ttl: 600
-    type: CNAME
-    value: proxyparty.recaptime.dev.
+#andreijiroh: # by https://github.com/ajhalili2006, but uses his first name as subdomain instead of github username
+#  - ttl: 600
+#    type: CNAME
+#    value: proxyparty.recaptime.dev.
 
 arjav: #by https://github.com/arjav0703
   - ttl: 600


### PR DESCRIPTION
<!--
This is a template, please modify it to fit your Pull Request. 

Please pick one option when multiple are presented in brackets.

Please title your PR like this: [Adding/Deleting/Updating] `subdomain.[hackclub.com/dino.icu/etc]`
-->

# Deleting `[ajhalili2006|andreijiroh].dino.icu`

## Description

Will reattempt to do https://github.com/hackclub/dns/pull/1684, possibly via Nest (fingers crossed) or other means. See https://github.com/hackclub/dns/pull/1686 for context and the original revert patch.
