### PR TITLE
adding authly dns

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -569,6 +569,10 @@ aurora:
   - ttl: 600
     type: CNAME
     value: cname.vercel-dns.com.
+authly: 
+  - ttl: 600
+    type: CNAME
+    value: dandililacs.github.io.
 forge:
   - ttl: 600
     type: CNAME


### PR DESCRIPTION
Adding authly.hackclub.com for an authentication-based ysws in the works
