### PR TITLE
Update hackclub.com.yaml

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2798,6 +2798,10 @@ portal.ctf:
   ttl: 600
   type: A
   value: 167.99.110.64
+protalvr:
+  - ttl: 600
+    type: CNAME
+    value: a.selfhosted.hackclub.com.
 postal:
   ttl: 600
   type: CNAME


### PR DESCRIPTION
This Pull Request adds the portalvr subdomain to the hackclub.com.yaml DNS configuration. The portalvr.hackclub.com subdomain will serve as a CNAME alias to a.selfhosted.hackclub.com.