### PR TITLE
Update hackclub.com.yaml

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2879,7 +2879,7 @@ portal.ctf:
   ttl: 600
   type: A
   value: 167.99.110.64
-protalvr:
+portalvr:
   - ttl: 600
     type: CNAME
     value: a.selfhosted.hackclub.com.


### PR DESCRIPTION
This Pull Request adds the `portalvr` & removes `protalvr` subdomain to the `hackclub.com.yaml` DNS configuration.