### PR TITLE
Add MX & SPF records for 1or0.hackclub.com to enable email

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -46,6 +46,26 @@ ihs:
   - ttl: 3600
     type: CNAME
     value: 0446ea696fc11998.vercel-dns-017.com.
+  - ttl: 3600
+    type: MX
+    value: mx.zoho.in.
+    priority: 10
+  - ttl: 3600
+    type: MX
+    value: mx2.zoho.in.
+    priority: 20
+  - ttl: 3600
+    type: MX
+    value: mx3.zoho.in.
+    priority: 50
+  - ttl: 3600
+    type: TXT
+    value: "v=spf1 include:zoho.in ~all"
+  - ttl: 3600
+    type: TXT
+    name: zmail._domainkey.1or0
+    value: "v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCKKyJiBWZBxQdbGUiGLxV140jFzg1lbRg4FmdieLlssc7nutSuXqroGRjqXA1O9myTxoQTh7f5tokrBRTdB3kxjIELePLraxHBzKi8tdhI3fx2qWeI5pndtdTkKpX3ucCCLDpCoH2kc5avNdlhvYNHp0ReU5Mwe3mF2FcCvCMpaQIDAQAB"
+    
 20230913174421pm._domainkey:
   type: TXT
   value: k=rsa\; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCbYfun+ZMwXJGRqp41sG/OXWPgbQd6Ewf/ccOBCvigm9LSarnT1QCUizzc+ZqBfSc4UTlJJx2hyhWYN6zFHibSndOBmY3y09uKuv7S4v3usfhpVVJZw9BOQLL4N9uIysrzLhVOfCpXiIIQQHn/a277SA8klIDfVcZkxdkyBRQDlQIDAQAB

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -64,8 +64,8 @@ ihs:
   - ttl: 3600
     type: TXT
     name: zmail._domainkey.1or0
-    value: "v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCKKyJiBWZBxQdbGUiGLxV140jFzg1lbRg4FmdieLlssc7nutSuXqroGRjqXA1O9myTxoQTh7f5tokrBRTdB3kxjIELePLraxHBzKi8tdhI3fx2qWeI5pndtdTkKpX3ucCCLDpCoH2kc5avNdlhvYNHp0ReU5Mwe3mF2FcCvCMpaQIDAQAB"
-    
+    value: "v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCKKyJiBWZBxQdbGUiGLxV140jFzg1lbRg4FmdieLlssc7nutSuXqroGRjqXA1O9myTxoQTh7f5tokrBRTdB3kxjIELePLraxHBzKi8tdhI3fx2qWeI5pndtdTkKpX3ucCCLDpCoH2kc5avNdlhvYNHp0ReU5Mwe3mF2FcCvCMpaQIDAQAB"    
+
 20230913174421pm._domainkey:
   type: TXT
   value: k=rsa\; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCbYfun+ZMwXJGRqp41sG/OXWPgbQd6Ewf/ccOBCvigm9LSarnT1QCUizzc+ZqBfSc4UTlJJx2hyhWYN6zFHibSndOBmY3y09uKuv7S4v3usfhpVVJZw9BOQLL4N9uIysrzLhVOfCpXiIIQQHn/a277SA8klIDfVcZkxdkyBRQDlQIDAQAB
@@ -4083,3 +4083,4 @@ hackducky: #add hackducky
   - ttl: 600
     type: CNAME
     value: 6be30c9fb60ab816.vercel-dns-017.com.
+


### PR DESCRIPTION
Description:

This PR adds the necessary MX and SPF DNS records to support email for 1or0.hackclub.com using Zoho Mail.

 Changes:
1.Added Zoho Mail MX records for 1or0.hackclub.com
2.Added SPF record for email verification
Purpose:
To configure email sending and receiving via Zoho Mail for the 1or0.hackclub.com subdomain.
Let me know if changes are required or additional records need to be added.