### PR TITLE
Update stemegypt.hackclub

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -429,6 +429,7 @@ _vercel:
     - vc-domain-verify=vidisha.hackclub.com,865c18c50e3614795dfc
     - vc-domain-verify=suceava.hackclub.com,b3c8f92fe1ba1f1f89f4
     - vc-domain-verify=stemegypt.hackclub.com,246d2979e0905d3792b8
+    - vc-domain-verify=eycc.stemegypt.hackclub.com,5962369a6ab4701c2401
     - vc-domain-verify=meltdown.hackclub.com,f6609cf94710dda22b0c
     - vc-domain-verify=visioneer.hackclub.com,b1bec26133a3a1d74d62
     - vc-domain-verify=vote.visioneer.hackclub.com,eacfb41e3088190eecbf
@@ -3286,6 +3287,10 @@ status.hcb:
     value: cname.appsignal-status.com.
 stemegypt:
   - ttl: 900
+    type: CNAME
+    value: cname.vercel-dns.com.
+eycc.stemegypt:
+  - ttl: 600
     type: CNAME
     value: cname.vercel-dns.com.
 stemsharkya:

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -428,8 +428,7 @@ _vercel:
     - vc-domain-verify=jua.hackclub.com,f187c5e6c1e4e681fb22
     - vc-domain-verify=vidisha.hackclub.com,865c18c50e3614795dfc
     - vc-domain-verify=suceava.hackclub.com,b3c8f92fe1ba1f1f89f4
-    - vc-domain-verify=stemegypt.hackclub.com,246d2979e0905d3792b8
-    - vc-domain-verify=eycc.stemegypt.hackclub.com,5962369a6ab4701c2401
+    - vc-domain-verify=stemegypt.hackclub.com,0c6e30f2705906e4924c
     - vc-domain-verify=meltdown.hackclub.com,f6609cf94710dda22b0c
     - vc-domain-verify=visioneer.hackclub.com,b1bec26133a3a1d74d62
     - vc-domain-verify=vote.visioneer.hackclub.com,eacfb41e3088190eecbf
@@ -3287,10 +3286,6 @@ status.hcb:
     value: cname.appsignal-status.com.
 stemegypt:
   - ttl: 900
-    type: CNAME
-    value: cname.vercel-dns.com.
-eycc.stemegypt:
-  - ttl: 600
     type: CNAME
     value: cname.vercel-dns.com.
 stemsharkya:

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1127,6 +1127,10 @@ coxmill:
   - ttl: 600
     type: CNAME
     value: modest-swanson-0a9aa6.netlify.app.
+crm.stemegypt:
+  - ttl: 600
+    type: CNAME
+    value: stemegypt-crm.42web.io.
 craft:
   - ttl: 600
     type: CNAME


### PR DESCRIPTION
# Updating `stemegypt.hackclub.com`
## Description
We've updated the Vercel project that hosts `stemegypt.hackclub.com`, so this PR updates the domain records to point to the new deployment.

The content and purpose of the site remain the same 