### PR TITLE
Update dino.icu.yaml

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -202,6 +202,11 @@ dev.hkgi: # HKGI test instance
   ttl: 3600
   type: CNAME
   value: garden.devcara.com.
+
+dhs:
+  ttl: 600
+  type: CNAME
+  value: dhshackclub.netlify.app.
   
 diafano: # cfanoulis/diafano-hackclub
   ttl: 600


### PR DESCRIPTION
Adding "dhs.dino.icu"

This subdomain will be used for our school's Hack Club: Damascus High School (DHS)