### PR TITLE
change news.hackclub.com to an alias and add a txt [1/2]

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2716,10 +2716,6 @@ newcanaanlib:
   type: CNAME
   value: cname.vercel-dns.com.
 # explanation - news is the user-facing domain, newspaper is for internal stuff (very confusing i know :pf:)
-news:
-  - ttl: 600
-    type: CNAME
-    value: cname.vercel-dns.com.
 newspaper:
   - ttl: 600
     type: CNAME


### PR DESCRIPTION
trying to add a google search console TXT record but apparently you can't combine TXT and CNAME :sob: (who built these standards weh)

[PART **1/2**] (merge this before part 2/2) - this PR removes news.hackclub.com as per the instructions on the readme