### PR TITLE
Adding `odyssey.hackclub.com`

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2787,7 +2787,7 @@ ocsa:
 odyssey:
   - ttl: 600
     type: CNAME
-    value: cname.vercel-dns.com.
+    value: odyssey-orpin.vercel.app.
 
 orpheus-engine:
   - type: CNAME


### PR DESCRIPTION
Adding a subdomain for the Athena event. This subdomain will be used to host the official website/landing page for Hack Club's Athena event, providing participants with event information, schedules, registration details, and resources. The subdomain will point to our Vercel deployment hosting the event website.
