### PR TITLE
Add CNAME record for midi.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2613,6 +2613,10 @@ middleman:
   ttl: 600
   type: CNAME
   value: middleman-hackclub.fly.dev.
+midi:
+  ttl: 600
+  type: CNAME
+  value: a.selfhosted.hackclub.com
 milton:
   ttl: 10000
   type: CNAME


### PR DESCRIPTION

Adding `midi.hackclub.com`

## Description

Added a CNAME record for a.selfhosted.hackclub.com -> **midi.hackclub.com** for hackclub/mini-midi-magic, a hardware midi instrument design YSWS
