### PR TITLE
Delete `midi.hackclub.com` DNS record

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2621,10 +2621,6 @@ middleman:
   ttl: 600
   type: CNAME
   value: middleman-hackclub.fly.dev.
-midi:
-  ttl: 600
-  type: CNAME
-  value: a.selfhosted.hackclub.com.
 milton:
   ttl: 10000
   type: CNAME


### PR DESCRIPTION
## Description

This pull request removes the DNS record for `midi.hackclub.com`. 