### PR TITLE
Try using fake credentials for test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,6 @@ jobs:
       - name: Do a dry run
         run: ./bin/dry-run
         env:
-          DNSIMPLE_ACCOUNT_NUMBER: ${{ secrets.DNSIMPLE_ACCOUNT_NUMBER }}
-          DNSIMPLE_API_KEY: ${{ secrets.DNSIMPLE_API_KEY }}
-          CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
+          DNSIMPLE_ACCOUNT_NUMBER: 123
+          DNSIMPLE_API_KEY: 'testapikey'
+          CLOUDFLARE_TOKEN: 'testapikey'


### PR DESCRIPTION
On PRs like https://github.com/hackclub/dns/pull/2014, the tests were failing because the credentials were failing to load on forked PRs.

I believe the tests are fixed now. I think the tests were failing because this PR was made from a personal fork, not from a branch in the main repo, so GitHub actions didn't pass real credentials to the test build for security reasons. I will do some refactoring then you should be good to continue.

I am going to need to merge this myself quickly so I can rebase 2 pending PRs on top of it.