### PR TITLE
test cf pages on octodns

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2324,6 +2324,13 @@ help.hcb:
   ttl: 300
   type: CNAME
   value: hcb.helpscoutdocs.com.
+helloleeksgetajob:
+  octodns:
+    cloudflare:
+      proxied: true
+  ttl: auto
+  type: CNAME
+  value: hackatime.pages.dev.
 hermes:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
in theory this was added on the cf side, so ocotdns should just see this and say "well my job here is done" and move on hunky dory