### PR TITLE
Adding slack-gateway.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3860,6 +3860,10 @@ slack-id:
   ttl: 300
   type: CNAME
   value: cname.vercel-dns.com.
+slack-gateway:
+  ttl: 300
+  type: CNAME
+  value: a.selfhosted.hackclub.com.
 slash-z:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
# Adding `slack-gateway.hackclub.com`

## Description

Used to invite people outside of Hack Club as Multi-Channel Guests for YSWS programs. See [`hackclub/slack-gateway`](https://github.com/hackclub/slack-gateway) for more details.