### PR TITLE
Adding aus.dino.icu

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -108,7 +108,12 @@ art: # by https://github.com/rajanwastaken
   ttl: 600
   type: CNAME
   value: particle-generativeart.netlify.app.
-  
+
+aus: # by https://github.com/bennygaming635
+  ttl: 600
+  type: A
+  value: 35.158.87.123
+
 aryanpatel: # by https://github.com/aryanpatel142006 
   ttl: 600
   type: CNAME


### PR DESCRIPTION
[Adding] `aus.dino.icu`

## Description

Decided together in #aus-hackers that we needed a collective website to list all of our clubs and manage them better as the offical Club Dashboard is honestly broken.

Demo site is currently visable as aushc.softr.app.
