### PR TITLE
Remove Chronicle

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1202,10 +1202,6 @@ christinaday2020:
 - ttl: 300
   type: CNAME
   value: hackclub.github.io.
-chronicle:
-- ttl: 300
-  type: A
-  value: 157.230.66.75
 churchill:
 - ttl: 300
   type: CNAME


### PR DESCRIPTION
# Delete `chronicle.hackclub.com`

## Description

`chronicle.hackclub.com` has an A record pointing to an IP that Hack Club no longer has control of. This was flagged as a subdomain takeover.