### PR TITLE
Point archive.hackclub.com to Cloudflare Tunnel for local server

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -625,10 +625,10 @@ angelhacksla:
 archive:
 - octodns:
     cloudflare:
-      proxied: false
+      proxied: true
   ttl: 300
   type: CNAME
-  value: archive.selfhosted.hackclub.com.
+  value: 493d65b3-2040-4db2-af28-ea33c026beb5.cfargotunnel.com.
 arker-demo:
 - octodns:
     cloudflare:


### PR DESCRIPTION
Moving archive.hackclub.com to a server hosted at a residential IP.