### PR TITLE
Remove 'place' DNS record due to IP takeover

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4292,10 +4292,6 @@ pl:
   ttl: 300
   type: CNAME
   value: a05569dabb46ea5b.vercel-dns-016.com.
-place:
-  ttl: 300
-  type: A
-  value: 96.126.108.99
 playphone:
   ttl: 300
   type: A


### PR DESCRIPTION
Removed the 'place' DNS record from the configuration.

<!--
This is a template, please modify it to fit your Pull Request. 

Please pick one option when multiple are presented in brackets.

Please title your PR like this: [Adding/Deleting/Updating] `subdomain.[hackclub.com/dino.icu/etc]`
-->

# [Adding/Deleting/Updating] `subdomain.[hackclub.com/dino.icu/etc]`

## Description of changes
<!-- Provide a description of the changes you are making. -->

## Website content/purpose
<!-- If you are adding a new subdomain, provide a quick description of the content/purpose of the website you plan to host. -->

## HQ Sponsor
<!-- If you are requesting a subdomain under `hackclub.com`, please state the name of your hq POC/sponsor: -->
