### PR TITLE
fixed typo in vercel for shipyard

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -376,7 +376,7 @@ _vercel:
   - vc-domain-verify=smelt.hackclub.com,e984b2fd8b23c434da2f
   - vc-domain-verify=security.hackclub.com,b005370fba78b1b3b932
   - vc-domain-verify=share.hackclub.com,8d59dacc58f46585b195
-  - vc-domain-verify=shipyard.hacklub.com,b2ea89879fcf86b38399
+  - vc-domain-verify=shipyard.hackclub.com,79b8509dc6a49d65b29f
   - vc-domain-verify=simmer.hackclub.com,19a5cdf65fc7aedb7ccb
   - vc-domain-verify=southhighhack.hackclub.com,8cf484f7551780f58ae9
   - vc-domain-verify=spatula.hackclub.com,91026edc4d735b166c59


### PR DESCRIPTION
<!--
This is a template, please modify it to fit your Pull Request. 

Please pick one option when multiple are presented in brackets.

Please title your PR like this: [Adding/Deleting/Updating] `subdomain.[hackclub.com/dino.icu/etc]`
-->

# Updating `shipyard.hackclub.com`

## Description of changes
When setting up my vercel, i did a typo of hacklub instead oh hackclub, so i couldn't verify meaning i couldn't use the domain.
i apologize for the confusion