### PR TITLE
Add cal.hackclub.com DNS records

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1237,6 +1237,10 @@ cad:
 - ttl: 300
   type: CNAME
   value: cname.vercel-dns.com.
+caffeinecrash:
+  ttl: 300
+  type: CNAME
+  value: a.selfhosted.hackclub.com.
 cal: # leo@hackclub.com U07BLJ1MBEE
   type: CNAME
   value: b.selfhosted.hackclub.com.
@@ -1246,10 +1250,6 @@ api.cal: # leo@hackclub.com U07BLJ1MBEE
 hq.cal: # leo@hackclub.com U07BLJ1MBEE
   type: CNAME
   value: b.selfhosted.hackclub.com.
-caffeinecrash:
-  ttl: 300
-  type: CNAME
-  value: a.selfhosted.hackclub.com.
 calendar:
   ttl: 300
   type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1237,6 +1237,15 @@ cad:
 - ttl: 300
   type: CNAME
   value: cname.vercel-dns.com.
+cal: # leo@hackclub.com U07BLJ1MBEE
+  type: CNAME
+  value: b.selfhosted.hackclub.com.
+api.cal: # leo@hackclub.com U07BLJ1MBEE
+  type: CNAME
+  value: b.selfhosted.hackclub.com.
+hq.cal: # leo@hackclub.com U07BLJ1MBEE
+  type: CNAME
+  value: b.selfhosted.hackclub.com.
 caffeinecrash:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
Add cal, api.cal, and hq.cal subdomains pointing to b.selfhosted.hackclub.com for Hack Club calendar.

<!--
This is a template, please modify it to fit your Pull Request. 

Please pick one option when multiple are presented in brackets.

Please title your PR like this: [Adding/Deleting/Updating] `subdomain.[hackclub.com/dino.icu/etc]`
-->

# [Adding/Deleting/Updating] `subdomain.[hackclub.com/dino.icu/etc]`

## Description of changes
<!-- Provide a description of the changes you are making. -->

## Website content/purpose
<!-- If you are adding a new subdomain, provide a quick description of the content/purpose of the website you plan to host. -->

## HQ Sponsor
<!-- If you are requesting a subdomain under `hackclub.com`, please state the name of your hq POC/sponsor: -->
