### PR TITLE
Add first.hackclub.com subdomain

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2234,6 +2234,9 @@ firehose:
 - ttl: 300
   type: CNAME
   value: cylindrical-rose-bklwrtred01ytycfprxq1lvm.herokudns.com.
+first: # @dhamari
+  type: CNAME
+  value: hackclub.github.io.
 fix: # jared@hackclub.com / lynn@hackclub.com
   type: CNAME
   value: 8d1bf7125214998b.vercel-dns-016.com.


### PR DESCRIPTION
## Summary
- Adds a CNAME record for `first.hackclub.com` pointing to `hackclub.github.io.`
- This serves the [hackclub/hackclub-frc-world](https://github.com/hackclub/hackclub-frc-world) repo via GitHub Pages
- Used as a redirect to `flavortown.hackclub.com` for FRC Worlds