### PR TITLE
Remove old club records

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4094,14 +4094,6 @@ photos: # tom@daamen.uk  U078PH0GBEH
 phs:
 - type: A
   value: 216.150.1.1 # Vercel
-- type: MX
-  values:
-  - exchange: mx1.improvmx.com.
-    preference: 1
-  - exchange: mx2.improvmx.com.
-    preference: 5
-- type: TXT
-  value: v=spf1 include:spf.improvmx.com ~all
 forms.phs:
 - ttl: 300
   type: CNAME
@@ -4284,14 +4276,6 @@ pullquests: # jared@hackclub.com / lynn@hackclub.com
 puyallup:
 - type: A
   value: 216.150.1.1 # Vercel
-- type: MX
-  values:
-  - exchange: mx1.improvmx.com.
-    preference: 1
-  - exchange: mx2.improvmx.com.
-    preference: 5
-- type: TXT
-  value: v=spf1 include:spf.improvmx.com ~all
 _h323cs._tcp.px:
   ttl: 300
   type: SRV


### PR DESCRIPTION
Removed MX and TXT records for hackclub.com and puyallup. contacted my old club and they only use the vercel, not the mx anymore.

<!--
This is a template, please modify it to fit your Pull Request. 

Please pick one option when multiple are presented in brackets.

Please title your PR like this: [Adding/Deleting/Updating] `subdomain.[hackclub.com/dino.icu/etc]`
-->

# [Adding/Deleting/Updating] `subdomain.[hackclub.com/dino.icu/etc]`

## Description of changes
<!-- Provide a description of the changes you are making. -->

## Website content/purpose
<!-- If you are adding a new subdomain, provide a quick description of the content/purpose of the website you plan to host. -->

## HQ Sponsor
<!-- If you are requesting a subdomain under `hackclub.com`, please state the name of your hq POC/sponsor: -->
