### PR TITLE
chore(hackclub.community): add DNS records for community PDS

### DIFF
--- a/hackclub.community.yaml
+++ b/hackclub.community.yaml
@@ -1,9 +1,4 @@
 ---
-# Hack Club Community PDS default handle suffix - https://github.com/hackclub-community/atproto-pds
-"*.bsky": # U07CAPBB9B5 andreijiroh@alumni.hackclub.community 
-- ttl: 300
-  type: CNAME
-  value: ajhalili2006.hackclub.app.
 _vercel:
 - ttl: 300
   type: TXT
@@ -96,6 +91,16 @@ aus: # benjamin.graetz@henleyhs.sa.edu.au U0828CN2BL4
 - ttl: 600
   type: A
   value: 35.158.87.123
+# Hack Club Community PDS default handle suffix base - https://github.com/hackclub-community/atproto-pds
+bsky: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community
+- ttl: 600
+  type: CNAME
+  value: ajhalili2006.hackclub.app.
+# Hack Club Community PDS default handle suffix - https://github.com/hackclub-community/atproto-pds
+"*.bsky": # U07CAPBB9B5 andreijiroh@alumni.hackclub.community
+- ttl: 300
+  type: CNAME
+  value: ajhalili2006.hackclub.app.
 create-mc: # grayson@vantilborg.ca U092DA495UY # This is for a create minecraft server, see channel C0AD3QV5C5D
 - ttl: 600
   type: A

--- a/hackclub.community.yaml
+++ b/hackclub.community.yaml
@@ -1,4 +1,9 @@
 ---
+# Hack Club Community PDS default handle suffix - https://github.com/hackclub-community/atproto-pds
+"*.bsky": # U07CAPBB9B5 andreijiroh@alumni.hackclub.community 
+- ttl: 300
+  type: CNAME
+  value: ajhalili2006.hackclub.app.
 _vercel:
 - ttl: 300
   type: TXT
@@ -116,6 +121,11 @@ n8n: # U07AGEVSTD2
 - ttl: 600
   type: CNAME
   value: felix1.hackclub.app.
+# Hack Club Community PDS server - https://github.com/hackclub-community/atproto-pds
+pds: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community 
+- ttl: 600
+  type: CNAME
+  value: ajhalili2006.hackclub.app.
 # https://github.com/hackclub-community/rsvp
 rsvp: # U08PUHSMW4V
 - ttl: 600

--- a/hackclub.community.yaml
+++ b/hackclub.community.yaml
@@ -127,7 +127,7 @@ n8n: # U07AGEVSTD2
   type: CNAME
   value: felix1.hackclub.app.
 # Hack Club Community PDS server - https://github.com/hackclub-community/atproto-pds
-pds: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community 
+pds: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community
 - ttl: 600
   type: CNAME
   value: ajhalili2006.hackclub.app.


### PR DESCRIPTION
# Adding `pds.hackclub.community` alongside `.bsky.hackclub.community` default handle suffix

## Description of changes
Going to setup a community AT Proto PDS instance for real via https://tangled.org/tranquil.farm/tranquil-pds so we can use Hack Club Auth for signins alongside being invite-only to handle abuse reports. IDK if the Nest team is ready for wildcards on the revamped platform, but let's see for now.

Note that the commit email points to my @recaptime-dev HQ address since I forgot to add my @hackclub-alumni one on my GitHub account.

## Website content/purpose
I am setting up a AT Proto PDS community instance for Hack Club community via https://tangled.org/tranquil.farm/tranquil-pds to integrate auth with Hack Club Auth instead of plain-old password auth in the reference PDS implementation by @bluesky-social.

## HQ Sponsor
<!-- If you are requesting a subdomain under `hackclub.com`, please state the name of your hq POC/sponsor: -->
Not applicable, although HQ staff can reach out via [`#atproto-pds-dev`](https://hackclub.enterprise.slack.com/archives/C09KQG6EALB) or [`#community-projects-ops`](https://hackclub.enterprise.slack.com/archives/C09FXK41C9W) Slack channels.