### PR TITLE
[Adding] labs.hackclub.community

### DIFF
--- a/hackclub.community.yaml
+++ b/hackclub.community.yaml
@@ -112,10 +112,6 @@ labs: # theawesomeaj.dev@gmail.com U092329JX89
 - ttl: 600
   type: CNAME
   value: 7b512cdc191b476c.vercel-dns-017.com.
-_vercel.labs: # theawesomeaj.dev@gmail.com U092329JX89
-- ttl: 600
-  type: TXT
-  value: vc-domain-verify=labs.hackclub.community,26555f7a32c65e2aef34
 n8n: # U07AGEVSTD2
 - ttl: 600
   type: CNAME

--- a/hackclub.community.yaml
+++ b/hackclub.community.yaml
@@ -4,6 +4,7 @@ _vercel:
   type: TXT
   values:
   - vc-domain-verify=stargazing.hackclub.community,6c036f41dd5fb04c3d06
+  - vc-domain-verify=labs.hackclub.community,26555f7a32c65e2aef34
 # Alumni Society (https://github.com/hackclub-alumni/meta/issues/1)
 # Records are primarily managed by @ajhalili2006 (U07CAPBB9B5), although other alums
 # can manage them by coordinating at #alums channel or https://github.com/hackclub-alumni/meta.

--- a/hackclub.community.yaml
+++ b/hackclub.community.yaml
@@ -107,6 +107,14 @@ knot: # ajhalili2006@crew.recaptime.dev U07CAPBB9B5
 - ttl: 300
   type: CNAME
   value: proxyparty.recaptime.dev.
+labs: # theawesomeaj.dev@gmail.com U092329JX89
+- ttl: 600
+  type: CNAME
+  value: 7b512cdc191b476c.vercel-dns-017.com.
+_vercel.labs: # theawesomeaj.dev@gmail.com U092329JX89
+- ttl: 600
+  type: TXT
+  value: vc-domain-verify=labs.hackclub.community,26555f7a32c65e2aef34
 n8n: # U07AGEVSTD2
 - ttl: 600
   type: CNAME


### PR DESCRIPTION
[Adding] `labs.hackclub.community`

## Description of changes
Added the subdomain and vercel verification

## Website content/purpose
A combined guides website for Hack Club (Merging [jams.hackclub.com](http://jams.hackclub.com/), [guides.hackclub.com](http://guides.hackclub.com/), and [workshops.hackclub.com](http://workshops.hackclub.com/)).

