### PR TITLE
chore(hackclub.community): add DNS record for HCEP site

### DIFF
--- a/hackclub.community.yaml
+++ b/hackclub.community.yaml
@@ -103,6 +103,10 @@ emoji: # alimad.co.ltd@gmail.com U08LQFRBL6S
 - ttl: 300
   type: CNAME
   value: emojiout.netlify.app.
+hceps: # andreijiroh@alumni.hackclub.community U07CAPBB9B5
+- ttl: 300
+  type: CNAME
+  value: hackclub-community.github.io.
 # https://tangled.org/recaptime.dev/knot-docker-nest
 knot: # ajhalili2006@crew.recaptime.dev U07CAPBB9B5
 - ttl: 300


### PR DESCRIPTION
<!--
This is a template, please modify it to fit your Pull Request. 

Please pick one option when multiple are presented in brackets.

Please title your PR like this: [Adding/Deleting/Updating] `subdomain.[hackclub.com/dino.icu/etc]`
-->

# Adding `hceps.hackclub.community`

## Description of changes
See https://github.com/hackclub-community/HCEP as well as https://github.com/hackclub-community/HCEP/issues/1 for details about the HCEP process, currently under development.

## Website content/purpose
It's a [Zensical](https://zensical.org)-based website rending those Markdown files for each proposal and also serves as permalinks for them.

## HQ Sponsor
<!-- If you are requesting a subdomain under `hackclub.com`, please state the name of your hq POC/sponsor: -->

None required since it's a community project, but I plan towards discussing the RFC-styled flow for community proposals in the `#meta` Slack channel soon.
