### PR TITLE
[Adding] `crux.hackclub.com`

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1694,7 +1694,7 @@ crates:
   value: b.selfhosted.hackclub.com.
 crux: # taran@events.hackclub.com
   type: CNAME
-  value: 8f10ff364485c907.vercel-dns-017.com.
+  value: 8c4560f252ccdc85.vercel-dns-016.com.
 css:
   type: CNAME
   value: eadd3e0fa0446c3c.vercel-dns-016.com.

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -291,6 +291,7 @@ _vercel:
   - vc-domain-verify=celestial.hackclub.com,712c9345didfd5e0b4ee
   - vc-domain-verify=codecafe.hackclub.com,7626bb39bfb56e9ea791
   - vc-domain-verify=contact-helper.hackclub.com,ecd049f45e2ad550fd89
+  - vc-domain-verify=crux.hackclub.com,fc8e0d78d0a7b8a91855
   - vc-domain-verify=descend.hackclub.com,766f399a5ac7216e01a1
   - vc-domain-verify=dessert.hackclub.com,8452d8879c3995b17783
   - vc-domain-verify=docs.identity.hackclub.com,ef5c12615db913aa8dee
@@ -1692,6 +1693,10 @@ crates:
       proxied: true
   type: CNAME
   value: b.selfhosted.hackclub.com.
+crux: # taran@events.hackclub.com
+- ttl: 300
+  type: CNAME
+  value: 8f10ff364485c907.vercel-dns-017.com
 css:
   type: CNAME
   value: eadd3e0fa0446c3c.vercel-dns-016.com.

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1696,7 +1696,7 @@ crates:
 crux: # taran@events.hackclub.com
 - ttl: 300
   type: CNAME
-  value: 8f10ff364485c907.vercel-dns-017.com
+  value: 8f10ff364485c907.vercel-dns-017.com.
 css:
   type: CNAME
   value: eadd3e0fa0446c3c.vercel-dns-016.com.

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -291,7 +291,6 @@ _vercel:
   - vc-domain-verify=celestial.hackclub.com,712c9345didfd5e0b4ee
   - vc-domain-verify=codecafe.hackclub.com,7626bb39bfb56e9ea791
   - vc-domain-verify=contact-helper.hackclub.com,ecd049f45e2ad550fd89
-  - vc-domain-verify=crux.hackclub.com,fc8e0d78d0a7b8a91855
   - vc-domain-verify=descend.hackclub.com,766f399a5ac7216e01a1
   - vc-domain-verify=dessert.hackclub.com,8452d8879c3995b17783
   - vc-domain-verify=docs.identity.hackclub.com,ef5c12615db913aa8dee
@@ -1694,7 +1693,6 @@ crates:
   type: CNAME
   value: b.selfhosted.hackclub.com.
 crux: # taran@events.hackclub.com
-- ttl: 300
   type: CNAME
   value: 8f10ff364485c907.vercel-dns-017.com.
 css:


### PR DESCRIPTION
# [Adding] `crux.hackclub.com`

## Description of changes
Adding dns record for crux.hackclub.com for horizons crux

## Website content/purpose
Event site for horizons crux. Purpose is to give event specific information, sponsors and have an event specific landing for advertising.

## HQ Sponsor
Phthallo
