### PR TITLE
chore(dns): update DNS records for community PDS service + contact details for Alumni Society's DNS records

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -77,10 +77,65 @@ _acme-challenge.ajhalili2006:
   type: CNAME
   value: 3a1ea03c191e234288b279704763e052._acme.deno.net.
 
-_github-pages-challenge-hackclub-alumni.alumni:
+# Alumni Society (https://github.com/hackclub-alumni/meta/issues/1)
+# Records are primarily managed by @ajhalili2006 (U07CAPBB9B5), although other alums
+# can manage them by coordinating at #alums channel or https://github.com/hackclub-alumni/meta.
+# Note that we have moved to hackclub.community, although we keep GH/GL Pages
+# domain verification record below to prevent domain takeovers if we do wildcard
+# CNAME records at *.alumni.dino.icu in future, alongside some email domain alias setup
+# for Uberspace.
+alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
+  # GitLab Pages - https://gitlab.com/hackclub-community/alumni/website
+- ttl: 600
+  type: A
+  value: 35.185.44.232
+- ttl: 600
+  type: AAAA
+  value: "2600:1901:0:7b8a::"
+  # Community mailbox for alums, currently managed by @ajhalili2006 on Uberspace [NOT PLANNED FOR SSO STUFF]
+  # If you are an alum, you can request one via Slack DMs or at https://gitlab.com/hackclub-community/alumni/meta/-/issues.
+- octodns:
+    cloudflare:
+      comment: "U8 mailbox - ajhalili@janus.uberspace.de"
+  ttl: 600
+  type: MX
+  values:
+  - exchange: in-mx.uberspace.de.
+    preference: 10
+- octodns:
+    cloudflare:
+      comment: "U8 mailbox - ajhalili@janus.uberspace.de"
+  ttl: 600
+  type: TXT
+  values:
+  - "uberspace-mail-rK2Mjse6RH"   # verification challenge
+  - "v=spf1 include:spf.uberspace.de ~all"   # SPF records
+_atproto.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
+- ttl: 600
+  type: TXT
+  value: "did=did:plc:yi5ewii4xerodl6ljn3fwga6"
+uberspace1._domainkey.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
+- octodns:
+    cloudflare:
+      comment: "U8 mailbox - ajhalili@janus.uberspace.de"
+  ttl: 600
+  type: CNAME
+  value: dkim1.uberspace.de.
+uberspace2._domainkey.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
+- octodns:
+    cloudflare:
+      comment: "U8 mailbox - ajhalili@janus.uberspace.de"
+  ttl: 600
+  type: CNAME
+  value: dkim2.uberspace.de.
+_github-pages-challenge-hackclub-alumni.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
 - ttl: 600
   type: TXT
   value: "3777bf5f9b6076520d8bbcebb90d45"
+_gitlab-pages-verification-code.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
+- ttl: 600
+  type: TXT
+  value: "gitlab-pages-verification-code=398259d364b40425aee99d9b0a6bec8d"
 
 amina: # by https://github.com/amino47
   ttl: 600
@@ -97,12 +152,6 @@ _acme-challenge.andreijiroh:
   type: CNAME
   value: abd77e2d22191e54d5f6c8ad24fcfd97._acme.deno.net.
 
-# Alumni Society (https://github.com/hackclub-alumni/meta/issues/1)
-# Records are primarily managed by @ajhalili2006 (U07CAPBB9B5), although other alums
-# can manage them by coordinating at #alums channel or https://github.com/hackclub-alumni/meta.
-# Note that we have moved to hackclub.community, although we keep GH Pages
-# domain verification record below to prevent domain takeovers if we do wildcard
-# CNAME records at *.alumni.dino.icu in future.
 andrew: # by https://github.com/anddddrew
   ttl: 600
   type: CNAME
@@ -187,6 +236,17 @@ bs: # by https://github.com/leecheeyong/BrawlBio
   ttl: 600
   type: CNAME
   value: cname.vercel-dns.com.
+
+# Hack Club Community PDS default handle suffix base - https://github.com/hackclub-community/atproto-pds
+bsky: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
+- ttl: 600
+  type: CNAME
+  value: ajhalili2006.hackclub.app.
+# Hack Club Community PDS default handle suffix - https://github.com/hackclub-community/atproto-pds
+"*.bsky": # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
+- ttl: 300
+  type: CNAME
+  value: ajhalili2006.hackclub.app.
 
 builders-club: #turtlesy1234@gmail.com U0AM2DYC3FB
 - ttl: 600

--- a/hackclub.community.yaml
+++ b/hackclub.community.yaml
@@ -53,7 +53,7 @@ uberspace2._domainkey.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.communit
   ttl: 600
   type: CNAME
   value: dkim2.uberspace.de.
-# GitHub organization domain verificiation
+# GitHub organization domain verification
 _gh-hackclub-alumni-o.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
 - ttl: 600
   type: TXT
@@ -68,7 +68,7 @@ _gitlab-pages-verification-code.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclu
   value: "gitlab-pages-verification-code=6084339db0c4e86155d8df639b6662d4"
 # GH Pages domain verification to prevent domain takeovers if we do
 # wildcard CNAME records at *.alumni.hackclub.community
-blog.alumni: # ajhalili2006@andreijiroh.dev U07CAPBB9B5 https://andreijiroh.dev/contact
+blog.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
 - ttl: 600
   type: CNAME
   value: 731fb7077db63b1d.vercel-dns-016.com.

--- a/hackclub.community.yaml
+++ b/hackclub.community.yaml
@@ -5,10 +5,11 @@ _vercel:
   values:
   - vc-domain-verify=stargazing.hackclub.community,6c036f41dd5fb04c3d06
   - vc-domain-verify=labs.hackclub.community,26555f7a32c65e2aef34
+
 # Alumni Society (https://github.com/hackclub-alumni/meta/issues/1)
 # Records are primarily managed by @ajhalili2006 (U07CAPBB9B5), although other alums
 # can manage them by coordinating at #alums channel or https://github.com/hackclub-alumni/meta.
-alumni: # ajhalili2006@andreijiroh.dev U07CAPBB9B5 https://andreijiroh.dev/contact
+alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
   # GitLab Pages - https://gitlab.com/hackclub-community/alumni/website
 - ttl: 600
   type: A
@@ -34,18 +35,18 @@ alumni: # ajhalili2006@andreijiroh.dev U07CAPBB9B5 https://andreijiroh.dev/conta
   values:
   - "uberspace-mail-gyCEpx0wY8"   # verification challenge
   - "v=spf1 include:spf.uberspace.de ~all"   # SPF records
-_atproto.alumni: # ajhalili2006@andreijiroh.dev U07CAPBB9B5 https://andreijiroh.dev/contact
+_atproto.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
 - ttl: 600
   type: TXT
   value: "did=did:plc:yi5ewii4xerodl6ljn3fwga6"
-uberspace1._domainkey.alumni: # ajhalili2006@andreijiroh.dev U07CAPBB9B5 https://andreijiroh.dev/contact
+uberspace1._domainkey.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
 - octodns:
     cloudflare:
       comment: "U8 mailbox - ajhalili@janus.uberspace.de"
   ttl: 600
   type: CNAME
   value: dkim1.uberspace.de.
-uberspace2._domainkey.alumni: # ajhalili2006@andreijiroh.dev U07CAPBB9B5 https://andreijiroh.dev/contact
+uberspace2._domainkey.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
 - octodns:
     cloudflare:
       comment: "U8 mailbox - ajhalili@janus.uberspace.de"
@@ -53,36 +54,40 @@ uberspace2._domainkey.alumni: # ajhalili2006@andreijiroh.dev U07CAPBB9B5 https:/
   type: CNAME
   value: dkim2.uberspace.de.
 # GitHub organization domain verificiation
-_gh-hackclub-alumni-o.alumni: # ajhalili2006@andreijiroh.dev U07CAPBB9B5 https://andreijiroh.dev/contact
+_gh-hackclub-alumni-o.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
 - ttl: 600
   type: TXT
   value: "d066f40ce3"
-# GH Pages domain verification to prevent domain takeovers if we do
-# wildcard CNAME records at *.alumni.hackclub.community
-_github-pages-challenge-hackclub-alumni.alumni: # ajhalili2006@andreijiroh.dev U07CAPBB9B5 https://andreijiroh.dev/contact
+_github-pages-challenge-hackclub-alumni.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
 - ttl: 600
   type: TXT
   value: "62688903c020be82f48ace03d54467"
+_gitlab-pages-verification-code.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
+- ttl: 600
+  type: TXT
+  value: "gitlab-pages-verification-code=6084339db0c4e86155d8df639b6662d4"
+# GH Pages domain verification to prevent domain takeovers if we do
+# wildcard CNAME records at *.alumni.hackclub.community
 blog.alumni: # ajhalili2006@andreijiroh.dev U07CAPBB9B5 https://andreijiroh.dev/contact
 - ttl: 600
   type: CNAME
   value: 731fb7077db63b1d.vercel-dns-016.com.
 # GitLab Pages-hosted redirect to https://social.dino.icu/@alumni, also serves as custom handle
 # for AT Proto bridged profile (managed by Bridgy Fed).
-fediverse.alumni: # ajhalili2006@andreijiroh.dev U07CAPBB9B5 https://andreijiroh.dev/contact
+fediverse.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
 - ttl: 600
   type: CNAME
   value: hackclub-community.gitlab.io.
 # Custom AT Proto handle for bridged fediverse profile (technically we could go with
 # @alumni.social.dino.icu to match the Hackstodon side
-_atproto.fediverse.alumni: # ajhalili2006@andreijiroh.dev U07CAPBB9B5 https://andreijiroh.dev/contact
+_atproto.fediverse.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
 - ttl: 600
   type: TXT
   value: "did=did:plc:pejmcpkvnajr4x3htexetbzc"
 # GitLab Pages verification challenge record (note that GitLab Pages uses Let's Encrypt over
 # HTTP-01 challenge method for TLS cert issuance).
 # Docs: https://gitlab.com/help/user/project/pages/custom_domains_ssl_tls_certification/_index.md#4-verify-the-domains-ownership
-_gitlab-pages-verification-code.fediverse.alumni: # ajhalili2006@andreijiroh.dev U07CAPBB9B5 https://andreijiroh.dev/contact
+_gitlab-pages-verification-code.fediverse.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
 - ttl: 600
   type: TXT
   value: "gitlab-pages-verification-code=6d5351c9c8ce7bc19be0bda5bdd4c4c5"
@@ -92,12 +97,12 @@ aus: # benjamin.graetz@henleyhs.sa.edu.au U0828CN2BL4
   type: A
   value: 35.158.87.123
 # Hack Club Community PDS default handle suffix base - https://github.com/hackclub-community/atproto-pds
-bsky: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community
+bsky: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
 - ttl: 600
   type: CNAME
   value: ajhalili2006.hackclub.app.
 # Hack Club Community PDS default handle suffix - https://github.com/hackclub-community/atproto-pds
-"*.bsky": # U07CAPBB9B5 andreijiroh@alumni.hackclub.community
+"*.bsky": # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
 - ttl: 300
   type: CNAME
   value: ajhalili2006.hackclub.app.
@@ -131,10 +136,13 @@ n8n: # U07AGEVSTD2
   type: CNAME
   value: felix1.hackclub.app.
 # Hack Club Community PDS server - https://github.com/hackclub-community/atproto-pds
-pds: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community
+pds: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
 - ttl: 600
-  type: CNAME
-  value: ajhalili2006.hackclub.app.
+  type: AAAA
+  value: 2a01:4f9:3081:399c::358
+  octodns:
+    cloudflare:
+      proxied: true
 # https://github.com/hackclub-community/rsvp
 rsvp: # U08PUHSMW4V
 - ttl: 600


### PR DESCRIPTION
# Updating `pds.hackclub.community` + `alumni.(hackclub.community|dino.icu)` and adding `*.bsky.dino.icu`

## Description of changes
This patchset include a DNS update for `pds.hackclub.community` to point to its Nest VM's public IPv6 address behind Cloudflare proxy for the firehose websockets to work properly, which is required for AT Proto relays to crawl through each account repo properly.

Alongside that is the usual routine maintenance involving updating contact details for Alumni Society related DNS records, setting up GitLab Pages on both `hackclub.community` and `dino.icu` domains and Uberspace 8 Beta email aliasing setup of `alumni.dino.icu` -> `alumni.hackclub.community`.

## Website content/purpose
See https://github.com/hackclub/dns/pull/2832 and https://github.com/hackclub-community/atproto-pds/issues/3 for context.

## HQ Sponsor
Not applicable since it's a community project but HQ/HCB staff and Fire Department may reach out to me and other (future) PDS admins via [`#atproto-pds-dev`](https://hackclub.enterprise.slack.com/archives/C09KQG6EALB) or [`#community-projects-ops`](https://hackclub.enterprise.slack.com/archives/C09FXK41C9W) Slack channels or by filing to the issue tracker at <https://github.com/hackclub-community/atproto-pds/issues>.
