### PR TITLE
Add CNAME record for beast in hackclub.com.yaml

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -970,6 +970,12 @@ bbss:
 - ttl: 300
   type: CNAME
   value: bbsshackclub.netlify.app.
+beast: #euan@hackclub.com
+- octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
+  value: b.selfhosted.hackclub.com.
 beat: #alexvd@hackclub.com
 - octodns:
     cloudflare:


### PR DESCRIPTION
claim beast.hackclub.com to point to coolify, the same resource will redirect to beest.hackclub.com to avoid confusion
