### PR TITLE
Adding cq.dino.icu

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -347,7 +347,10 @@ corechat: # aradforsure@gmaul.com U0AJN9LJDGS
   ttl: 600
   type: CNAME
   value: aradjpy.github.io.
-
+cq: # @ruben (U0AHNB20WDD) on slack, ruben@scstudios.tech https://github.com/code2344/contact-website
+  ttl: 600
+  type: A
+  value: 216.198.79.1
 cr:
   ttl: 600
   type: CNAME


### PR DESCRIPTION
<!--
This is a template, please modify it to fit your Pull Request. 

Please pick one option when multiple are presented in brackets.

Please title your PR like this: [Adding/Deleting/Updating] `subdomain.[hackclub.com/dino.icu/etc]`
-->

# Adding cq.dino.icu

## Description of changes
Adding cq.dino.icu as a subdomain (I am hosting on vercel

## Website content/purpose
It is a website for the (currently a draft) YSWS called CQ (or Contact) about amateur radio.

## HQ Sponsor
None yet.