### PR TITLE
chore(hackclub.community): use emergency Azure VM setup for PDS-related PLC operations

### DIFF
--- a/hackclub.community.yaml
+++ b/hackclub.community.yaml
@@ -100,12 +100,12 @@ aus: # benjamin.graetz@henleyhs.sa.edu.au U0828CN2BL4
 bsky: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
 - ttl: 600
   type: CNAME
-  value: ajhalili2006.hackclub.app.
+  value: 20.193.145.115
 # Hack Club Community PDS default handle suffix - https://github.com/hackclub-community/atproto-pds
 "*.bsky": # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
 - ttl: 300
   type: CNAME
-  value: ajhalili2006.hackclub.app.
+  value: pds.
 create-mc: # grayson@vantilborg.ca U092DA495UY # This is for a create minecraft server, see channel C0AD3QV5C5D
 - ttl: 600
   type: A
@@ -138,11 +138,8 @@ n8n: # U07AGEVSTD2
 # Hack Club Community PDS server - https://github.com/hackclub-community/atproto-pds
 pds: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
 - ttl: 600
-  type: AAAA
-  value: 2a01:4f9:3081:399c::358
-  octodns:
-    cloudflare:
-      proxied: true
+  type: A
+  value: 20.193.145.115
 # https://github.com/hackclub-community/rsvp
 rsvp: # U08PUHSMW4V
 - ttl: 600

--- a/hackclub.community.yaml
+++ b/hackclub.community.yaml
@@ -100,12 +100,12 @@ aus: # benjamin.graetz@henleyhs.sa.edu.au U0828CN2BL4
 bsky: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
 - ttl: 600
   type: CNAME
-  value: 20.193.145.115
+  value: pds.hackclub.community.
 # Hack Club Community PDS default handle suffix - https://github.com/hackclub-community/atproto-pds
 "*.bsky": # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
 - ttl: 300
   type: CNAME
-  value: pds.
+  value: pds.hackclub.community.
 create-mc: # grayson@vantilborg.ca U092DA495UY # This is for a create minecraft server, see channel C0AD3QV5C5D
 - ttl: 600
   type: A


### PR DESCRIPTION
# Updating `(*.bsky|pds).hackclub.community`

## Description of changes
This is a emergency patch to allow PDS migration of `@alumni.hackclub.community` (@hackclub-alumni) and @moderation.bsky.hackclub.community to another PDS host in the Atmosphere, before proceeding with the mass cleanups on hackclub.community later this weekend as requested by a HQ staff over Signal and by the Fire Department.

## Website content/purpose
See https://github.com/hackclub-community/atproto-pds for details

## HQ Sponsor
None needed.
