### PR TITLE
chore(dns): do DNS records cleanup on `hackclub.community` and update contact details for `(ajhalili2006|andreijiroh|alumni).dino.icu`

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -80,10 +80,6 @@ _acme-challenge.ajhalili2006: # ajhalili2006@andreijiroh.dev https://gitlab.com/
 # Alumni Society (https://github.com/hackclub-alumni/meta/issues/1)
 # Records are primarily managed by @ajhalili2006 (U07CAPBB9B5), although other alums
 # can manage them by coordinating at #alums channel or https://github.com/hackclub-alumni/meta.
-# Note that we have moved to hackclub.community, although we keep GH/GL Pages
-# domain verification record below to prevent domain takeovers if we do wildcard
-# CNAME records at *.alumni.dino.icu in future, alongside some email domain alias setup
-# for Uberspace.
 alumni: # andreijiroh@alumni.dino.icu https://github.com/hackclub-alumni/meta
   # GitLab Pages - https://gitlab.com/hackclub-community/alumni/website
 - ttl: 600
@@ -114,14 +110,6 @@ _atproto.alumni: # andreijiroh@alumni.dino.icu https://github.com/hackclub-alumn
 - ttl: 600
   type: TXT
   value: "did=did:plc:yi5ewii4xerodl6ljn3fwga6"
-_gh-hackclub-alumni-o.alumni: # andreijiroh@alumni.dino.icu https://github.com/hackclub-alumni/meta
-- ttl: 600
-  type: TXT
-  value: "73477a0c9e"
-blog.alumni: # andreijiroh@alumni.dino.icu https://github.com/hackclub-alumni/meta
-- ttl: 600
-  type: CNAME
-  value: 731fb7077db63b1d.vercel-dns-016.com.
 uberspace1._domainkey.alumni: # andreijiroh@alumni.dino.icu https://github.com/hackclub-alumni/meta
 - octodns:
     cloudflare:
@@ -136,6 +124,10 @@ uberspace2._domainkey.alumni: # andreijiroh@alumni.dino.icu https://github.com/h
   ttl: 600
   type: CNAME
   value: dkim2.uberspace.de.
+_gh-hackclub-alumni-o.alumni: # andreijiroh@alumni.dino.icu https://github.com/hackclub-alumni/meta
+- ttl: 600
+  type: TXT
+  value: "73477a0c9e"
 _github-pages-challenge-hackclub-alumni.alumni: # andreijiroh@alumni.dino.icu https://github.com/hackclub-alumni/meta
 - ttl: 600
   type: TXT
@@ -144,6 +136,10 @@ _gitlab-pages-verification-code.alumni: # andreijiroh@alumni.dino.icu https://gi
 - ttl: 600
   type: TXT
   value: "gitlab-pages-verification-code=398259d364b40425aee99d9b0a6bec8d"
+blog.alumni: # andreijiroh@alumni.dino.icu https://github.com/hackclub-alumni/meta
+- ttl: 600
+  type: CNAME
+  value: 731fb7077db63b1d.vercel-dns-016.com.
 
 amina: # by https://github.com/amino47
   ttl: 600
@@ -625,9 +621,9 @@ icons: # yoda - https://github.com/yodalightsabr/icons-dino-icu - a CDN for @hac
   value: 76.76.21.21
 
 inherit: # contact at mtthsschrbr@proton.me or @mtthsschrbr on slack
-  - ttl: 600
-    type: CNAME
-    value: cname.vercel-dns.com.
+- ttl: 600
+  type: CNAME
+  value: cname.vercel-dns.com.
 
 _dmarc.inherit: # contact at mtthsschrbr@proton.me or @mtthsschrbr on slack
   ttl: 3600
@@ -640,14 +636,14 @@ resend._domainkey.inherit: # contact at mtthsschrbr@proton.me or @mtthsschrbr on
   value: "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDlFn8+Ep0RP8e791QcpRDe8I8vHHt378umytGa4/+UJAS+tfC8VeQqMohtrwzo3bW5emTeGqcsNrJKOE5FZW6zvam5xgtQ6WTZd/wwXXImVz403m1hpD84gYTZkeQ4zKojeMLz373og767Q7GxJSjCTH7IiPy+fRKotinpMn6FnwIDAQAB"
 
 send.inherit: # contact at mtthsschrbr@proton.me or @mtthsschrbr on slack
-  - ttl: 3600
-    type: MX
-    values:
-      - priority: 10
-        value: feedback-smtp.eu-west-1.amazonses.com.
-  - ttl: 3600
-    type: TXT
-    value: "v=spf1 include:amazonses.com ~all"
+- ttl: 3600
+  type: MX
+  values:
+  - priority: 10
+    value: feedback-smtp.eu-west-1.amazonses.com.
+- ttl: 3600
+  type: TXT
+  value: "v=spf1 include:amazonses.com ~all"
 
 innohacks: #efe
   ttl: 600

--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -67,12 +67,12 @@ airborne: # by U0807ADEC6L // @Manan
   type: CNAME
   value: cname.vercel-dns.com.
 
-ajhalili2006: # by https://github.com/ajhalili2006 via https://github.com/andreijiroh-dev/website
+ajhalili2006: # ajhalili2006@andreijiroh.dev https://gitlab.com/andreijiroh-dev/launchpad
 - ttl: 600
   type: A
     # https://github.com/andreijiroh-dev/api-servers/tree/main/apps/redirector, hosted on Deno Deploy
   value: 69.67.170.170
-_acme-challenge.ajhalili2006:
+_acme-challenge.ajhalili2006: # ajhalili2006@andreijiroh.dev https://gitlab.com/andreijiroh-dev/launchpad
 - ttl: 600
   type: CNAME
   value: 3a1ea03c191e234288b279704763e052._acme.deno.net.
@@ -84,7 +84,7 @@ _acme-challenge.ajhalili2006:
 # domain verification record below to prevent domain takeovers if we do wildcard
 # CNAME records at *.alumni.dino.icu in future, alongside some email domain alias setup
 # for Uberspace.
-alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
+alumni: # andreijiroh@alumni.dino.icu https://github.com/hackclub-alumni/meta
   # GitLab Pages - https://gitlab.com/hackclub-community/alumni/website
 - ttl: 600
   type: A
@@ -108,31 +108,39 @@ alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/h
   ttl: 600
   type: TXT
   values:
-  - "uberspace-mail-rK2Mjse6RH"   # verification challenge
+  - "uberspace-mail-kPUHau2GGz"   # verification challenge
   - "v=spf1 include:spf.uberspace.de ~all"   # SPF records
-_atproto.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
+_atproto.alumni: # andreijiroh@alumni.dino.icu https://github.com/hackclub-alumni/meta
 - ttl: 600
   type: TXT
   value: "did=did:plc:yi5ewii4xerodl6ljn3fwga6"
-uberspace1._domainkey.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
+_gh-hackclub-alumni-o.alumni: # andreijiroh@alumni.dino.icu https://github.com/hackclub-alumni/meta
+- ttl: 600
+  type: TXT
+  value: "73477a0c9e"
+blog.alumni: # andreijiroh@alumni.dino.icu https://github.com/hackclub-alumni/meta
+- ttl: 600
+  type: CNAME
+  value: 731fb7077db63b1d.vercel-dns-016.com.
+uberspace1._domainkey.alumni: # andreijiroh@alumni.dino.icu https://github.com/hackclub-alumni/meta
 - octodns:
     cloudflare:
       comment: "U8 mailbox - ajhalili@janus.uberspace.de"
   ttl: 600
   type: CNAME
   value: dkim1.uberspace.de.
-uberspace2._domainkey.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
+uberspace2._domainkey.alumni: # andreijiroh@alumni.dino.icu https://github.com/hackclub-alumni/meta
 - octodns:
     cloudflare:
       comment: "U8 mailbox - ajhalili@janus.uberspace.de"
   ttl: 600
   type: CNAME
   value: dkim2.uberspace.de.
-_github-pages-challenge-hackclub-alumni.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
+_github-pages-challenge-hackclub-alumni.alumni: # andreijiroh@alumni.dino.icu https://github.com/hackclub-alumni/meta
 - ttl: 600
   type: TXT
   value: "3777bf5f9b6076520d8bbcebb90d45"
-_gitlab-pages-verification-code.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
+_gitlab-pages-verification-code.alumni: # andreijiroh@alumni.dino.icu https://github.com/hackclub-alumni/meta
 - ttl: 600
   type: TXT
   value: "gitlab-pages-verification-code=398259d364b40425aee99d9b0a6bec8d"
@@ -142,12 +150,12 @@ amina: # by https://github.com/amino47
   type: CNAME
   value: amino47.github.io.
 
-andreijiroh: # by https://github.com/ajhalili2006, but uses his first name as subdomain instead of github username
+andreijiroh: # ajhalili2006@andreijiroh.dev https://gitlab.com/andreijiroh-dev/launchpad
 - ttl: 600
   type: A
     # https://github.com/andreijiroh-dev/api-servers/tree/main/apps/redirector, hosted on Deno Deploy
   value: 69.67.170.170
-_acme-challenge.andreijiroh:
+_acme-challenge.andreijiroh: # ajhalili2006@andreijiroh.dev https://gitlab.com/andreijiroh-dev/launchpad
 - ttl: 600
   type: CNAME
   value: abd77e2d22191e54d5f6c8ad24fcfd97._acme.deno.net.
@@ -237,16 +245,16 @@ bs: # by https://github.com/leecheeyong/BrawlBio
   type: CNAME
   value: cname.vercel-dns.com.
 
-# Hack Club Community PDS default handle suffix base - https://github.com/hackclub-community/atproto-pds
-bsky: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
+# Default handle suffix base for @recaptime.dev's PDS service
+# See https://gitlab.com/recaptime-dev/hosted-services/atproto-pds for details
+bsky: # andreijiroh@alumni.dino.icu https://github.com/hackclub-alumni/meta
 - ttl: 600
   type: CNAME
-  value: ajhalili2006.hackclub.app.
-# Hack Club Community PDS default handle suffix - https://github.com/hackclub-community/atproto-pds
-"*.bsky": # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
+  value: proxyparty.recaptime.dev.
+"*.bsky": # andreijiroh@alumni.dino.icu https://github.com/hackclub-alumni/meta
 - ttl: 300
   type: CNAME
-  value: ajhalili2006.hackclub.app.
+  value: proxyparty.recaptime.dev.
 
 builders-club: #turtlesy1234@gmail.com U0AM2DYC3FB
 - ttl: 600

--- a/hackclub.community.yaml
+++ b/hackclub.community.yaml
@@ -22,15 +22,6 @@ emoji: # alimad.co.ltd@gmail.com U08LQFRBL6S
 - ttl: 300
   type: CNAME
   value: emojiout.netlify.app.
-hceps: # andreijiroh@alumni.hackclub.community U07CAPBB9B5
-- ttl: 300
-  type: CNAME
-  value: hackclub-community.github.io.
-# https://tangled.org/recaptime.dev/knot-docker-nest
-knot: # ajhalili2006@crew.recaptime.dev U07CAPBB9B5
-- ttl: 300
-  type: CNAME
-  value: proxyparty.recaptime.dev.
 labs: # theawesomeaj.dev@gmail.com U092329JX89
 - ttl: 600
   type: CNAME

--- a/hackclub.community.yaml
+++ b/hackclub.community.yaml
@@ -6,106 +6,10 @@ _vercel:
   - vc-domain-verify=stargazing.hackclub.community,6c036f41dd5fb04c3d06
   - vc-domain-verify=labs.hackclub.community,26555f7a32c65e2aef34
 
-# Alumni Society (https://github.com/hackclub-alumni/meta/issues/1)
-# Records are primarily managed by @ajhalili2006 (U07CAPBB9B5), although other alums
-# can manage them by coordinating at #alums channel or https://github.com/hackclub-alumni/meta.
-alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
-  # GitLab Pages - https://gitlab.com/hackclub-community/alumni/website
-- ttl: 600
-  type: A
-  value: 35.185.44.232
-- ttl: 600
-  type: AAAA
-  value: "2600:1901:0:7b8a::"
-  # Community mailbox for alums, currently managed by @ajhalili2006 on Uberspace [NOT PLANNED FOR SSO STUFF]
-  # If you are an alum, you can request one via Slack DMs or at https://gitlab.com/hackclub-community/alumni/meta/-/issues.
-- octodns:
-    cloudflare:
-      comment: "U8 mailbox - ajhalili@janus.uberspace.de"
-  ttl: 600
-  type: MX
-  values:
-  - exchange: in-mx.uberspace.de.
-    preference: 10
-- octodns:
-    cloudflare:
-      comment: "U8 mailbox - ajhalili@janus.uberspace.de"
-  ttl: 600
-  type: TXT
-  values:
-  - "uberspace-mail-gyCEpx0wY8"   # verification challenge
-  - "v=spf1 include:spf.uberspace.de ~all"   # SPF records
-_atproto.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
-- ttl: 600
-  type: TXT
-  value: "did=did:plc:yi5ewii4xerodl6ljn3fwga6"
-uberspace1._domainkey.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
-- octodns:
-    cloudflare:
-      comment: "U8 mailbox - ajhalili@janus.uberspace.de"
-  ttl: 600
-  type: CNAME
-  value: dkim1.uberspace.de.
-uberspace2._domainkey.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
-- octodns:
-    cloudflare:
-      comment: "U8 mailbox - ajhalili@janus.uberspace.de"
-  ttl: 600
-  type: CNAME
-  value: dkim2.uberspace.de.
-# GitHub organization domain verification
-_gh-hackclub-alumni-o.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
-- ttl: 600
-  type: TXT
-  value: "d066f40ce3"
-_github-pages-challenge-hackclub-alumni.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
-- ttl: 600
-  type: TXT
-  value: "62688903c020be82f48ace03d54467"
-_gitlab-pages-verification-code.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
-- ttl: 600
-  type: TXT
-  value: "gitlab-pages-verification-code=6084339db0c4e86155d8df639b6662d4"
-# GH Pages domain verification to prevent domain takeovers if we do
-# wildcard CNAME records at *.alumni.hackclub.community
-blog.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
-- ttl: 600
-  type: CNAME
-  value: 731fb7077db63b1d.vercel-dns-016.com.
-# GitLab Pages-hosted redirect to https://social.dino.icu/@alumni, also serves as custom handle
-# for AT Proto bridged profile (managed by Bridgy Fed).
-fediverse.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
-- ttl: 600
-  type: CNAME
-  value: hackclub-community.gitlab.io.
-# Custom AT Proto handle for bridged fediverse profile (technically we could go with
-# @alumni.social.dino.icu to match the Hackstodon side
-_atproto.fediverse.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
-- ttl: 600
-  type: TXT
-  value: "did=did:plc:pejmcpkvnajr4x3htexetbzc"
-# GitLab Pages verification challenge record (note that GitLab Pages uses Let's Encrypt over
-# HTTP-01 challenge method for TLS cert issuance).
-# Docs: https://gitlab.com/help/user/project/pages/custom_domains_ssl_tls_certification/_index.md#4-verify-the-domains-ownership
-_gitlab-pages-verification-code.fediverse.alumni: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
-- ttl: 600
-  type: TXT
-  value: "gitlab-pages-verification-code=6d5351c9c8ce7bc19be0bda5bdd4c4c5"
-
 aus: # benjamin.graetz@henleyhs.sa.edu.au U0828CN2BL4
 - ttl: 600
   type: A
   value: 35.158.87.123
-# Hack Club Community PDS default handle suffix base - https://github.com/hackclub-community/atproto-pds
-bsky: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
-- ttl: 600
-  type: CNAME
-  value: pds.hackclub.community.
-# Hack Club Community PDS default handle suffix - https://github.com/hackclub-community/atproto-pds
-"*.bsky": # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
-- ttl: 300
-  type: CNAME
-  value: pds.hackclub.community.
 create-mc: # grayson@vantilborg.ca U092DA495UY # This is for a create minecraft server, see channel C0AD3QV5C5D
 - ttl: 600
   type: A
@@ -135,11 +39,6 @@ n8n: # U07AGEVSTD2
 - ttl: 600
   type: CNAME
   value: felix1.hackclub.app.
-# Hack Club Community PDS server - https://github.com/hackclub-community/atproto-pds
-pds: # U07CAPBB9B5 andreijiroh@alumni.hackclub.community https://github.com/hackclub-alumni/meta
-- ttl: 600
-  type: A
-  value: 20.193.145.115
 # https://github.com/hackclub-community/rsvp
 rsvp: # U08PUHSMW4V
 - ttl: 600
@@ -149,8 +48,3 @@ stats: # alimad.co.ltd@gmail.com U08LQFRBL6S
 - ttl: 300
   type: CNAME
   value: Alimadcorp.github.io.
-# https://github.com/hackclub-community/community-services-status
-status: # ajhalili2006@crew.recaptime.dev U07CAPBB9B5
-- ttl: 300
-  type: CNAME
-  value: hackclub-community.github.io.


### PR DESCRIPTION
> [!warning]
> **Just a heads up regarding the test error**: Since this involves removing a lot of records at `hackclub.community`, manual intervention with `--force` is required when deploying to production.

# Updating `[andreijiroh|ajhalili2006|alumni|*.bsky].dino.icu` and cleaning up `hackclub.community

## Description of changes
Please see https://gitlab.com/andreijiroh-dev/hackclub-final-signoff/-/blob/main/README.md for context behind this patch for those unfamiliar with the whole situation.

Regarding the removal of `alumni.hackclub.community` DNS records, there's a high chance someone may maliciously claim it, add MX records and impersonate me (cue the `andreijiroh@alumni.hackclub.community` address) in the worse case scenario as I switch back @hackclub-alumni's domain to `alumni.dino.icu` so if someone want to claim it I would like to be notified in the future as a security measure.

This is also a follow-up to a earlier patch at https://github.com/hackclub/dns/pull/2875 involving some PLC recovery operations with some AT Proto accounts on the now-defunct `pds.hackclub.community` instance.

## Website content/purpose
_This section was left blank on purpose._

## HQ Sponsor
Not required.
