### PR TITLE
macondo: cut over to LFD (Orchard) ingress

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3629,7 +3629,7 @@ macondo: # nathan@hackclub.com
     cloudflare:
       proxied: true
   type: CNAME
-  value: a.selfhosted.hackclub.com.
+  value: ingress.lfdl.ink.
 magazine: # acon@hackclub.com U04KEK4TS72
 - ttl: 600
   type: CNAME


### PR DESCRIPTION
## Summary

Repoint `macondo.hackclub.com` from `a.selfhosted.hackclub.com.` (Coolify) to `ingress.lfdl.ink.` (the LFD/Orchard cluster).

The Macondo app (codename `lynx`, repo [hackclub/codename-lynx](https://github.com/hackclub/codename-lynx)) is moving its production deploy to LFD. The cluster ingress for `macondo.hackclub.com` is already live on LFD with a Let's Encrypt cert via Traefik. Cloudflare proxy stays on. The existing Coolify deployment remains in place as a fallback but will receive no traffic once this merges.

DNS validation against the LFD API (`validate_dns`) returns:
> Please create a CNAME record pointing macondo.hackclub.com to ingress.lfdl.ink

which matches this change.

## Test plan
- [x] octodns deploy applies the CNAME change cleanly
- [x] `dig macondo.hackclub.com` returns Cloudflare edges (proxy on, CNAME chain hidden)
- [x] `curl -I https://macondo.hackclub.com` returns a 200 from the new LFD pod (verify build hash / response header)
- [x] If anything looks off, revert this PR. Coolify deployment is still healthy.