### PR TITLE
Revert "macondo: cut over to LFD (Orchard) ingress (#2879)"

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3629,7 +3629,7 @@ macondo: # nathan@hackclub.com
     cloudflare:
       proxied: true
   type: CNAME
-  value: ingress.lfdl.ink.
+  value: a.selfhosted.hackclub.com.
 magazine: # acon@hackclub.com U04KEK4TS72
 - ttl: 600
   type: CNAME


### PR DESCRIPTION
Reverts #2879. Rolls macondo.hackclub.com back from ingress.lfdl.ink to a.selfhosted.hackclub.com.