### PR TITLE
chore: move heist to b server

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3059,9 +3059,8 @@ hear:
   type: CNAME
   value: cname.vercel-dns.com.
 heist:
-- ttl: 300
   type: CNAME
-  value: heist.iunstable0.com.
+  value: b.selfhosted.hackclub.com.
 heist-api:
 - ttl: 300
   type: CNAME


### PR DESCRIPTION
## Summary
- Point `heist.hackclub.com` CNAME from `heist.iunstable0.com` to `b.selfhosted.hackclub.com.`

Mirrors the recent draw-dino move pattern (#2886).