### PR TITLE
Deleting gh-oauth.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2561,13 +2561,6 @@ giftbox: # tongyu@hackclub.com U07DJMFAQQP
   ttl: 300
   type: CNAME
   value: 4711668836b198ab.vercel-dns-016.com.
-github-oauth:
-- octodns:
-    cloudflare:
-      proxied: true
-  ttl: 300
-  type: CNAME
-  value: a.selfhosted.hackclub.com.
 glenny:
 - ttl: 300
   type: CNAME


### PR DESCRIPTION
# Deleting `gh-oauth.hackclub.com`

## Description of changes
Repo archived yesterday; the subdomain was made irrelevant by Hack Pack & GH Edu Pack no longer existing and dinoissours team invites were added to draw-dino, making the domain officially obsolete