### PR TITLE
Add A record for shaswat with specified value

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -6181,3 +6181,6 @@ zwp:
 - ttl: 300
   type: A
   value: 172.99.233.117
+shaswat: # shaswatkumar9868@gmail
+  - type: A
+    value: 216.198.79.1


### PR DESCRIPTION
# Adding `shaswat.dino.icu`

## Description of changes
- Added a new DNS configuration block under the `dino.icu.yaml` file.
- Configured a standard A record to route the `shaswat` subdomain directly to my Vercel app deployment.