### PR TITLE
Add A record for shaswat in dino.icu.yaml

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -1129,6 +1129,10 @@ shammah: # by https://github.com/Gijutsu-T
   type: CNAME
   value: cname.vercel-dns.com.
 
+shaswat: # shaswatkumar9868@gmail.com U09E9GMP2TX
+  - type: A
+    value: 216.198.79.1
+
 shipathon: # christian U0938MZG8Q6
 - ttl: 600
   type: A


### PR DESCRIPTION
# Adding `shaswat.dino.icu`

## Description of changes
- Added a new DNS configuration block under the `dino.icu.yaml` file.
- Configured a standard A record to route the `shaswat` subdomain directly to my Vercel app deployment.