### PR TITLE
Disable Cloudflare proxy for `platform.game.hackclub.com`

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2481,6 +2481,9 @@ game: # arav@hackclub.com U01MPHKFZ7S
   type: CNAME
   value: a.selfhosted.hackclub.com.
 platform.game: # ascpixi@hackclub.com U082DPCGPST
+  octodns:
+    cloudflare:
+      proxied: false
   type: CNAME
   value: b.selfhosted.hackclub.com.
 gamebit:


### PR DESCRIPTION
Updated Cloudflare proxy settings for octodns.

<!--
This is a template, please modify it to fit your Pull Request. 

Please pick one option when multiple are presented in brackets.

Please title your PR like this: [Adding/Deleting/Updating] `subdomain.[hackclub.com/dino.icu/etc]`
-->

# [Adding/Deleting/Updating] `subdomain.[hackclub.com/dino.icu/etc]`

## Description of changes
<!-- Provide a description of the changes you are making. -->

## Website content/purpose
<!-- If you are adding a new subdomain, provide a quick description of the content/purpose of the website you plan to host. -->

## HQ Sponsor
<!-- If you are requesting a subdomain under `hackclub.com`, please state the name of your hq POC/sponsor: -->
