### PR TITLE
Adding ascension.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -682,6 +682,9 @@ ascend:
 - ttl: 300
   type: CNAME
   value: cname.vercel-dns.com.
+ascension: # joysu2008@gmail.com U09G78T3MM2
+  - type: CNAME
+    value: ascension.grassier.tech.
 asia-summit:
 - ttl: 300
   type: CNAME


### PR DESCRIPTION
# Adding `ascension.hackclub.com`

## Description of changes
Adding a CNAME record for the `ascension` subdomain pointing to `ascension.grassier.tech.`

## Website content/purpose
Ascension (art/design-focused YSWS) landing page/platform

## HQ Sponsor
Tongyu (@bucketfish)