### PR TITLE
Fix hack.club update

### DIFF
--- a/config/production.yaml
+++ b/config/production.yaml
@@ -79,7 +79,7 @@ zones:
     sources:
       - config
     targets:
-      - cloudflare
+      - cloudflare-alt
   hackclub.app.:
     lenient: true
     sources:


### PR DESCRIPTION
Update the Cloudflare account configuration to use an alternate setup. This change modifies the target from `cloudflare` to `cloudflare-alt`.

