### PR TITLE
 [Updating] `snake.hackclub.com`

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5147,7 +5147,7 @@ smhs:
   value: zephyril.github.io.
 snake: # U07EB2Y76DP
   - type: CNAME
-    value: yousnakewesnake.pages.dev.
+    value: yousnakewesnake.netlify.app.
     ttl: 600
 socktalk:
 - octodns:


### PR DESCRIPTION
# [Updating] `snake.hackclub.com`

## Description of changes
CNAME is to Netlify because HQ's Cloudflare gives a `CNAME Cross-User Banned` error due to different accounts. This is temporary, as we hope to move this to Vercel in the near future.