### PR TITLE
Add raffle.stardance.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5285,6 +5285,9 @@ beta.stardance: #kartikey@hackclub.com
 em9599.stardance: # kartikey@hackclub.com
   type: CNAME
   value: u57277233.wl234.sendgrid.net.
+raffle.stardance: # kartikey@hackclub.com
+  type: CNAME
+  value: a.selfhosted.hackclub.com.
 url1054.stardance: # kartikey@hackclub.com
   type: CNAME
   value: sendgrid.net.


### PR DESCRIPTION
# Adding `raffle.stardance.hackclub.com`

## Description of changes
Adding raffle 

## Website content/purpose
16 week AMD GPU raffle we're running

## HQ Sponsor
Max/Zach/Kartikey etc.
[Relevant thread](https://hackclub.slack.com/archives/C0AR0M43H61/p1780440299493169)