### PR TITLE
fix: raffle.stardance

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5300,7 +5300,10 @@ em9599.stardance: # kartikey@hackclub.com
   value: u57277233.wl234.sendgrid.net.
 raffle.stardance: # kartikey@hackclub.com
   type: CNAME
-  value: a.selfhosted.hackclub.com.
+  value: 5.161.197.219
+  octodns:
+    cloudflare:
+      proxied: true
 url1054.stardance: # kartikey@hackclub.com
   type: CNAME
   value: sendgrid.net.


### PR DESCRIPTION


# Updating raffle.stardance.hackclub.com

## Description of changes
Fix from a.selfhosted.hackclub.com to the Stardance server & add Cloudflare proxying

## Website content/purpose
GPU Raffle

## HQ Sponsor
@cskartikey 