### PR TITLE
Add alchemize CNAME entry to hackclub.com.yaml

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -455,6 +455,10 @@ ai: # mahad@hackclub.com U059VC0UDEU
   ttl: 300
   type: CNAME
   value: b.selfhosted.hackclub.com.
+alchemize: # mahasankarshant@gmail.com U096RMRG03G
+- ttl: 300
+  type: CNAME
+  value: b.selfhosted.hackclub.com.
 docs.ai: # mahad@hackclub.com U059VC0UDEU
 - ttl: 300
   type: CNAME


### PR DESCRIPTION
Adding alchemize.hackclub.com (b.selfhosted.hackclub.com - on coolify), a new ysws. Project approved by @JosiasAurel 