### PR TITLE
Add ari subdomain to hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -655,6 +655,12 @@ backend.arena:
   ttl: 300
   type: CNAME
   value: fd39bf74a906c3be.vercel-dns-017.com.
+ari: # nathan@hackclub.com
+  octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
+  value: a.selfhosted.hackclub.com.
 armed:
 - octodns:
     cloudflare:


### PR DESCRIPTION
Adds the `ari.hackclub.com` subdomain pointing to the Coolify self-hosted infrastructure.

```yaml
ari: # nathan@hackclub.com
  octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.selfhosted.hackclub.com.
```

- **Type:** CNAME → `a.selfhosted.hackclub.com.` (Coolify selfhosted)
- **Cloudflare:** proxied
- **Contact:** nathan@hackclub.com

Follows the exact same pattern as the existing `macondo` and `scraps` records. Added alphabetically between `arena` and `armed`.