### PR TITLE
Adding `shutter.hackclub.com`

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5049,6 +5049,12 @@ shush:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
+shutter: # maxtran@hackclub.com U07F6FMJ97U
+  octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 sidequests:
   octodns:
     cloudflare:


### PR DESCRIPTION
# Adding `shutter.hackclub.com`

## Description of changes
Added CNAME record under "shutter" on `hackclub.com.yaml` pointing to Orchard

## Website content/purpose
A daily photo journal platform / shared photo album for the 2026 summer interns called "Shutter"

## HQ Sponsor
@leowilkin 
