### PR TITLE
Adding newsroom.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3993,12 +3993,6 @@ news: # eps@hackclub.com U09Q8MLTE58 & hc+dns@matmanna.dev U07VA44DNBA;
 - type: TXT
   values:
   - google-site-verification=Mc08Mplkv-e0eNBR0VW3ogoctBoozEETwZvrb-9prb0
-newsroom: # eps@hackclub.com U09Q8MLTE58 & hc+dns@matmanna.dev U07VA44DNBA;
-- octodns:
-    cloudflare:
-      proxied: true
-  type: A
-  value: 5.161.100.52 # a.selfhosted.hackclub.com
 newspaper:
 - octodns:
     cloudflare:
@@ -4006,6 +4000,12 @@ newspaper:
   ttl: 300
   type: CNAME
   value: a.selfhosted.hackclub.com.
+newsroom: # eps@hackclub.com U09Q8MLTE58 & hc+dns@matmanna.dev U07VA44DNBA;
+- octodns:
+    cloudflare:
+      proxied: true
+  type: A
+  value: 5.161.100.52 # a.selfhosted.hackclub.com
 nexus: #manitej@hackclub.com
 - octodns:
     cloudflare:

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3984,7 +3984,7 @@ newcanaanlib:
   ttl: 300
   type: CNAME
   value: cname.vercel-dns.com.
-news: # explanation - news is the user-facing domain, newspaper is for internal stuff (very confusing i know :pf:)
+news: # eps@hackclub.com U09Q8MLTE58 & hc+dns@matmanna.dev U07VA44DNBA;
 - octodns:
     cloudflare:
       proxied: true
@@ -3993,6 +3993,12 @@ news: # explanation - news is the user-facing domain, newspaper is for internal 
 - type: TXT
   values:
   - google-site-verification=Mc08Mplkv-e0eNBR0VW3ogoctBoozEETwZvrb-9prb0
+newsroom: # eps@hackclub.com U09Q8MLTE58 & hc+dns@matmanna.dev U07VA44DNBA;
+- octodns:
+    cloudflare:
+      proxied: true
+  type: A
+  value: 5.161.100.52 # a.selfhosted.hackclub.com
 newspaper:
 - octodns:
     cloudflare:


### PR DESCRIPTION
# Adding newsroom.hackclub.com

## Description of changes

Adds hc.com subdomain for the newsroom and updates the contact for news.hc for consistency

## Website content/purpose

Internal (for-now) CMS for Slacker News (news.hc)

## HQ Sponsor

Evan (eps)