### PR TITLE
Adding doseguard.dino.icu

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -435,6 +435,11 @@ doruk:
   type: CNAME
   value: itsimpeccable.github.io.
 
+doseguard: # U0B8LTW45QV https://github.com/darshnerd/DoseGuard
+  ttl: 600
+  type: AAAA
+  value: 2a01:4f9:3081:399c::732
+
 e: # drawing app - by https://github.com/sporeball
   ttl: 600
   type: CNAME


### PR DESCRIPTION
# [Adding] `doseguard.dino.icu`

## Description of changes
Adds an AAAA record for `doseguard.dino.icu` pointing at my Hack Club
container, where I'm self-hosting the app.

```yaml
doseguard: # darsh U0B8LTW45QV
  ttl: 600
  type: AAAA
  value: 2a01:4f9:3081:399c::732
```

## Website content/purpose

YSWS project -> DoseGuard is a medication-safety web app: you scan a medicine label, it OCRs
the text, resolves the brand/salt to real ingredients, 


## HQ Sponsor