### PR TITLE
camp, summer-camp

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5450,15 +5450,15 @@ summer:
     preference: 10
   - exchange: aspmx4.googlemail.com.
     preference: 10
-lb.summer:
-  type: A
-  value: 45.8.201.37
 summer-camp: # jenin@hackclub.com // U0926UASBJ7
   octodns:
     cloudflare:
       proxied: true
   type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
+lb.summer:
+  type: A
+  value: 45.8.201.37
 summit:
   type: CNAME
   value: b0215d46951fd2c5.vercel-dns-016.com.

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1267,12 +1267,12 @@ calendar:
   ttl: 300
   type: CNAME
   value: ghs.googlehosted.com.
-camp: # jenin@hackclub.com // U0926UASBJ7 
+camp: # jenin@hackclub.com // U0926UASBJ7
   octodns:
     cloudflare:
       proxied: true
   type: CNAME
-  value: a.selfhosted.hackclub.com.
+  value: a.ingress.tier2.infra.hackclub.com.
 camp-apply:
   ttl: 300
   type: CNAME
@@ -5449,6 +5449,12 @@ summer:
 lb.summer:
   type: A
   value: 45.8.201.37
+summer-camp: # jenin@hackclub.com // U0926UASBJ7
+  octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 summit:
   type: CNAME
   value: b0215d46951fd2c5.vercel-dns-016.com.


### PR DESCRIPTION
 - camp (hackclub.com.yaml:1270) — value changed to a.ingress.tier2.infra.hackclub.com., Cloudflare-proxied CNAME, commented # jenin@hackclub.com //
  U0926UASBJ7
  - summer-camp (new) — same target, same proxied CNAME format, same ownership comment, inserted alphabetically between summer/lb.summer and summit