### PR TITLE
Adding 'wisp.hackclub.com'

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5931,7 +5931,7 @@ windmill:
   ttl: 300
   type: CNAME
   value: a.selfhosted.hackclub.com.
-wisp:
+wisp: # mgoldbergspar@gmail.com U08TCSANHDX
 - ttl: 300
   type: CNAME
   value: rxs0o9.k.hackclub.dev.

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5931,6 +5931,10 @@ windmill:
   ttl: 300
   type: CNAME
   value: a.selfhosted.hackclub.com.
+wisp:
+- ttl: 300
+  type: CNAME
+  value: rxs0o9.k.hackclub.dev.
 wl:
 - ttl: 300
   type: CNAME


### PR DESCRIPTION
# Adding `wisp.hackclub.com`

## Description of changes
added wisp.hackclub.com, ysws about making tiny hardware projects. part of 2026 summer internship.

## Website content/purpose
website for wisp, ysws for making tiny hardware projects. ys: hardware project, ws: funding + swag

## HQ Sponsor
Dev (YSWS intern manager)
Leo @leowilkin 