### PR TITLE
Stop using CF for Resolution

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4675,9 +4675,6 @@ renaissance-24:
   type: CNAME
   value: 1bdc13681dff9b21.vercel-dns-016.com.
 resolution: # dhamari@hackclub.com // jenin@hackclub.com
-- octodns:
-    cloudflare:
-      proxied: true
   type: A
   value: 216.150.1.1 # Vercel
 - ttl: 3600

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4675,7 +4675,7 @@ renaissance-24:
   type: CNAME
   value: 1bdc13681dff9b21.vercel-dns-016.com.
 resolution: # dhamari@hackclub.com // jenin@hackclub.com
-  type: A
+- type: A
   value: 216.150.1.1 # Vercel
 - ttl: 3600
   type: TXT


### PR DESCRIPTION
<!--
This is a template, please modify it to fit your Pull Request. 

Please pick one option when multiple are presented in brackets.

Please title your PR like this: [Adding/Deleting/Updating] `subdomain.[hackclub.com/dino.icu/etc]`
-->

# Updating `resolution.hackclub.com`

## Description of changes
CF is in front of Vercel for no reason! This PR removes it.

## Website content/purpose
Removes CF to use Vercel's Edge network.
## HQ Sponsor
Dhamari