### PR TITLE
Palatine Hill

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4270,6 +4270,10 @@ pagering: # hey@gideon.sh U09D42Q0ARJ
   ttl: 300
   type: CNAME
   value: 5105b9b8d814fbc1.vercel-dns-017.com.
+palatine: # foxmoss@mediaology.com
+- ttl: 300
+  type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com
 pancakes: #niko@nikoo.dev
   octodns:
     cloudflare:


### PR DESCRIPTION
# Adding `palatine.hackclub.com`

## Description of changes
Adds the Palatine Hill Website to the main HackClub domain 

## Website content/purpose
This is a YSWS for the 2026 Summer Intern batch, a software jam prioritizing selling your ideas first. 

## HQ Sponsor
@leowilkin 
