### PR TITLE
Add DNS record for elyra.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2001,6 +2001,10 @@ elapsed: # U0A9B38F413
   ttl: 300
   type: CNAME
   value: 91e515501c1f1d5b.vercel-dns-017.com.
+elyra: # Owner - vinayaktiwari307@gmail.com - Official Website of Elyra Club
+  ttl: 300
+  type: CNAME
+  value: elyra-club.vinayaktiwari307.workers.dev.
 em4440: # SendGrid Sender Authentication (bank@hackclub.com)
   ttl: 300
   type: CNAME


### PR DESCRIPTION
# Adding `elyra.hackclub.com`

## Description of changes

Adding a new DNS record for `elyra.hackclub.com` pointing to the Elyra Club website hosted on Cloudflare Workers.

## Website content/purpose

Elyra Club is a teen-led innovation and technology community powered by Hack Club. Our goal is to help students learn, build, and create through workshops, projects, and collaborative learning.

The website serves as the official hub for the club, featuring information about our community, skill arenas (Web Development, Robotics, App Development, and Game Development), events, workshops, and registration links for new members.

## HQ Sponsor

Told by Manitej - Horizons to do in it.
