### PR TITLE
Add elyraclub.dino.icu for Elyra Club

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -463,6 +463,16 @@ elapsed: # U0A9B38F413
     cloudflare:
       proxied: true
 
+elyraclub: # vinayaktiwari307@gmail.com
+- ttl: 600
+  type: A
+  value: 216.198.79.1
+
+www.elyraclub: # vinayaktiwari307@gmail.com
+- ttl: 600
+  type: CNAME
+  value: bd87f6ad6e9810ac.vercel-dns-017.com.
+
 emojile: # wordle with slack emojis - https://github.com/yodalightsabr/emojile
   ttl: 600
   type: CNAME


### PR DESCRIPTION
R# Adding `elyraclub.dino.icu`

## Description of changes

Added DNS records for `elyraclub.dino.icu` and `www.elyraclub.dino.icu` to connect the Elyra Club website hosted on Vercel.

## Website content/purpose

Elyra Club is a student-led community focused on technology, creativity, and learning. The website serves as the club's main hub, providing information about projects, events, resources, and community activities.
