### PR TITLE
Adding boxbay.hackclub.com for Moving Day Docker registry

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1155,6 +1155,10 @@ bounce:
 - ttl: 300
   type: CNAME
   value: custom-email-domain.stripe.com.
+boxbay: # U083W5CCFDG joaquin@hackclub.com
+  ttl: 300
+  type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com
 branch:
 - ttl: 300
   type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1158,7 +1158,7 @@ bounce:
 boxbay: # U083W5CCFDG joaquin@hackclub.com
   ttl: 300
   type: CNAME
-  value: a.ingress.tier2.infra.hackclub.com
+  value: a.ingress.tier2.infra.hackclub.com.
 branch:
 - ttl: 300
   type: CNAME


### PR DESCRIPTION
# Adding `boxbay.hackclub.com`

## Description of changes
Adding boxbay, which points to a Docker container registry I'm hosting on Orchard for the Moving Day YSWS and future YSWS under my command.

## Website content/purpose
Points to a Docker container registry hosted on Orchard.

## HQ Sponsor
Me! I'm a gap year.
