### PR TITLE
Update macondo to point to a.ingress.tier2.infra.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3702,7 +3702,7 @@ macondo: # nathan@hackclub.com
     cloudflare:
       proxied: true
   type: CNAME
-  value: a.selfhosted.hackclub.com.
+  value: a.ingress.tier2.infra.hackclub.com.
 magazine: # acon@hackclub.com U04KEK4TS72
   type: CNAME
   value: cname.vercel-dns.com.


### PR DESCRIPTION
Updates the `macondo` CNAME in `hackclub.com.yaml` to point to the tier2 ingress.

- **Before:** `a.selfhosted.hackclub.com.`
- **After:** `a.ingress.tier2.infra.hackclub.com.`

Cloudflare `proxied: true` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)