### PR TITLE
Add ziademad-ai-eng.dino.icu subdomain

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -1474,12 +1474,14 @@ proxy.you-ship-we-vote:
   type: A
   value: 209.112.91.50
 
+ziademad-ai-eng:
+  ttl: 600
+  type: CNAME
+  value: cname.vercel-dns.com.
+
 zoneout: # kilecraft90@gmail.com U08GCDHM0QZ
 - ttl: 600
   type: CNAME
   value: cname.vercel-dns.com.
 
-ziademad-ai-eng: # ziad.1024087@stemoctober.moe.edu.eg
-  ttl: 600
-  type: CNAME
-  value: cname.vercel-dns.com.
+

--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -1478,3 +1478,8 @@ zoneout: # kilecraft90@gmail.com U08GCDHM0QZ
 - ttl: 600
   type: CNAME
   value: cname.vercel-dns.com.
+
+ziademad-ai-eng: 
+  - ttl: 600
+    type: CNAME
+    value: cname.vercel-dns.com.

--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -1479,7 +1479,7 @@ zoneout: # kilecraft90@gmail.com U08GCDHM0QZ
   type: CNAME
   value: cname.vercel-dns.com.
 
-ziademad-ai-eng: 
-  - ttl: 600
-    type: CNAME
-    value: cname.vercel-dns.com.
+ziademad-ai-eng: # ziad.1024087@stemoctober.moe.edu.eg
+  ttl: 600
+  type: CNAME
+  value: cname.vercel-dns.com.


### PR DESCRIPTION
# Adding `ziademad-ai-eng.dino.icu`

## Description of changes
Added the `ziademad-ai-eng` subdomain under `dino.icu` in alphabetical order, pointing to Vercel DNS (`cname.vercel-dns.com.`) to properly route my portfolio website.

## Website content/purpose
This is my personal developer portfolio website featuring AI engineering projects, full-stack work, and custom canvas/UI animations.

## HQ Sponsor
None (Using the community-open `dino.icu` domain).