### PR TITLE
Update dino.icu.yaml

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -627,16 +627,6 @@ heramb:
   type: CNAME
   value: cname.vercel-dns.com.
 
-hg: # HSL - U08004V1Z7T - helioleles@comcast.net - +1 (215) 410-5236
-- ttl: 600
-  type: CNAME
-  value: him.hackclub.app.
-
-hgcontent: # HSL - U08004V1Z7T - helioleles@comcast.net - +1 (215) 410-5236
-- ttl: 600
-  type: CNAME
-  value: him.hackclub.app.
-
 hi: # doruk.dino.icu email address
 - ttl: 600
   type: TXT
@@ -1483,6 +1473,12 @@ proxy.you-ship-we-vote:
 - ttl: 600
   type: A
   value: 209.112.91.50
+
+ziademad-ai-eng: # myfreelancinglife777@gmail.com U0A57CQPJHF
+  - ttl: 600
+    type: CNAME
+    value: cname.vercel-dns.com.
+
 
 zoneout: # kilecraft90@gmail.com U08GCDHM0QZ
 - ttl: 600


### PR DESCRIPTION
# Adding `ziademad-ai-eng.dino.icu`

## Description of changes
Added the `ziademad-ai-eng` subdomain under `dino.icu` in alphabetical order with required contact info, pointing to Vercel DNS.

## Website content/purpose
This is my personal developer portfolio website featuring AI engineering projects, full-stack work, and custom canvas/UI animations.

## HQ Sponsor
None.