### PR TITLE
Update dino.icu.yaml

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -1484,6 +1484,11 @@ proxy.you-ship-we-vote:
   type: A
   value: 209.112.91.50
 
+ziademad-ai-eng: # myfreelancinglife777@gmail.com U0A57CQPJHF
+- ttl: 600
+  type: A
+  value: 216.198.79.1
+
 zoneout: # kilecraft90@gmail.com U08GCDHM0QZ
 - ttl: 600
   type: CNAME


### PR DESCRIPTION
# Adding `ziademad-ai-eng.dino.icu`

## Description of changes
Added an A record for the `ziademad-ai-eng` subdomain pointing to Vercel's updated IP address (`216.198.79.1`) to resolve the invalid configuration error.

## Website content/purpose
Personal AI Engineering portfolio website.

## HQ Sponsor
N/A (Using dino.icu)