### PR TITLE
Remove octodns configuration from help.hcb

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3044,6 +3044,9 @@ graph.hcb: # echo@hackclub.com U080A3QP42C
   type: CNAME
   value: a393a61874975956.vercel-dns-016.com.
 help.hcb: #alex@hackclub.com, gary@hackclub.com
+- octodns:
+    cloudflare:
+      proxied: false
   ttl: 300
   type: CNAME
   value: us.intercomhelpcenter.com.


### PR DESCRIPTION
Removed octodns configuration from help.hcb.

<!--
This is a template, please modify it to fit your Pull Request. 

Please pick one option when multiple are presented in brackets.

Please title your PR like this: [Adding/Deleting/Updating] `subdomain.[hackclub.com/dino.icu/etc]`
-->

# [Adding/Deleting/Updating] `subdomain.[hackclub.com/dino.icu/etc]`

## Description of changes
<!-- Provide a description of the changes you are making. -->

## Website content/purpose
<!-- If you are adding a new subdomain, provide a quick description of the content/purpose of the website you plan to host. -->

## HQ Sponsor
<!-- If you are requesting a subdomain under `hackclub.com`, please state the name of your hq POC/sponsor: -->
