### PR TITLE
Remove https://gharbiya.hackclub.com/ (DNS takeover)

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2652,10 +2652,6 @@ gh-proxy:
   ttl: 300
   type: CNAME
   value: b.selfhosted.hackclub.com.
-gharbiya: # gh.hackclub@gmail.com U0666VATMT5
-- ttl: 300
-  type: CNAME
-  value: stemgharbiya.github.io.
 giftbox: # tongyu@hackclub.com U07DJMFAQQP
   octodns:
     cloudflare:


### PR DESCRIPTION
https://gharbiya.hackclub.com/ is currently a proxy of ESPN india and not hack club related


