### PR TITLE
Add dash.camp.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -703,8 +703,8 @@ ascend:
   type: CNAME
   value: cname.vercel-dns.com.
 ascension: # joysu2008@gmail.com U09G78T3MM2
-  - type: CNAME
-    value: cname.vercel-dns.com.
+- type: CNAME
+  value: cname.vercel-dns.com.
 asia-summit:
 - ttl: 300
   type: CNAME
@@ -1298,9 +1298,9 @@ hq.cal: # leo@hackclub.com U07BLJ1MBEE
   type: CNAME
   value: b.selfhosted.hackclub.com.
 calculate: # candyisakat@gmail.com U082PKSD15L
-  - ttl: 600
-    type: CNAME
-    value: 084f9b3358c26923.vercel-dns-017.com.
+- ttl: 600
+  type: CNAME
+  value: 084f9b3358c26923.vercel-dns-017.com.
 calendar:
   ttl: 300
   type: CNAME
@@ -1311,16 +1311,16 @@ camp: # jenin@hackclub.com // U0926UASBJ7
       proxied: true
   type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
+camp-apply:
+  ttl: 300
+  type: CNAME
+  value: hackcamp-apply.netlify.com.
 dash.camp: # jenin@hackclub.com // U0926UASBJ7
   octodns:
     cloudflare:
       proxied: true
   type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
-camp-apply:
-  ttl: 300
-  type: CNAME
-  value: hackcamp-apply.netlify.com.
 campfire: # leafd@hackclub.com
 - octodns:
     lenient: true
@@ -1530,9 +1530,9 @@ cken:
   type: A
   value: 52.191.165.18
 clam: # mihir@hackclub.com U0BC86VAYT0
-  - type: A
-    value: 141.148.195.78
-    ttl: 600
+- type: A
+  value: 141.148.195.78
+  ttl: 600
 bag.client:
   ttl: 300
   type: A
@@ -2321,8 +2321,8 @@ fallout: # samliu@hackclub.com
   type: CNAME
   value: ingress.lfdl.ink.
 lab.fallout: # enigmaticprojectorpheus@proton.me
-    type: A
-    value: 158.220.92.237
+  type: A
+  value: 158.220.92.237
 lets.fallout: # samliu@hackclub.com
   octodns:
     cloudflare: # do not proxy
@@ -2498,7 +2498,7 @@ forge-cdn: # aarav@hackclub.com
   ttl: 300
   type: CNAME
   value: b.selfhosted.hackclub.com.
-  
+
 format:
   octodns:
     cloudflare:
@@ -3420,7 +3420,7 @@ inkling:
   type: CNAME
   value: a.selfhosted.hackclub.com.
 insertCoin: # gblackburn088@gmail.com
-  ttl: 300 
+  ttl: 300
   type: CNAME
   value: a.selfhosted.hackclub.com.
 intercom-files: #alexd@hackclub.com U02CWS020SD
@@ -3615,7 +3615,7 @@ jv:
   value: awesome-carson-c7b5e3.netlify.com.
 keeb: #U05JNJZJ0BS
 - ttl: 300
-  type: CNAME 
+  type: CNAME
   value: a.selfhosted.hackclub.com.
 keepsake:
   type: CNAME
@@ -5334,9 +5334,9 @@ smhs:
   type: CNAME
   value: zephyril.github.io.
 snake: # U07EB2Y76DP
-  - type: CNAME
-    value: yousnakewesnake.netlify.app.
-    ttl: 600
+- type: CNAME
+  value: yousnakewesnake.netlify.app.
+  ttl: 600
 socktalk:
 - octodns:
     cloudflare:
@@ -6064,11 +6064,11 @@ wggs:
 whereisjaredisaacmanrightnowatthis-moment: # willsbuilds@hackclub.com
 - type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
-  ttl: 300 
+  ttl: 300
 whimsy: # katiesue@hackclub.com
-  - type: CNAME
-    value: ad97879918161518.vercel-dns-017.com.
-    ttl: 600
+- type: CNAME
+  value: ad97879918161518.vercel-dns-017.com.
+  ttl: 600
 whs:
 - ttl: 300
   type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1311,6 +1311,12 @@ camp: # jenin@hackclub.com // U0926UASBJ7
       proxied: true
   type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
+dash.camp: # jenin@hackclub.com // U0926UASBJ7
+  octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 camp-apply:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
Adds `dash.camp.hackclub.com` with the same DNS records as `camp.hackclub.com` — a Cloudflare-proxied CNAME to `a.ingress.tier2.infra.hackclub.com.`, placed directly under the `camp` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)