### PR TITLE
Adding `feud.hackclub.com`

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2337,6 +2337,10 @@ fett: # jared@hackclub.com U07HEH4N8UV
 - ttl: 300
   type: CNAME
   value: bc88611c121f3104.vercel-dns-016.com.
+feud # emme@hackclub.com U0BELFW91AN
+- ttl: 300
+  type: CNAME
+  value: cname.vercel-dns.com
 fhs:
 - ttl: 300
   type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2337,10 +2337,10 @@ fett: # jared@hackclub.com U07HEH4N8UV
 - ttl: 300
   type: CNAME
   value: bc88611c121f3104.vercel-dns-016.com.
-feud # emme@hackclub.com U0BELFW91AN
+feud: # emme@hackclub.com U0BELFW91AN
 - ttl: 300
   type: CNAME
-  value: cname.vercel-dns.com
+  value: cname.vercel-dns.com.
 fhs:
 - ttl: 300
   type: CNAME


### PR DESCRIPTION
# Adding `feud.hackclub.com`

## Description of changes
Adding the feud.hackclub.com subdomain 

## Website content/purpose
Subdomain for the 2-day local multiplayer game YSWS Feud

## HQ Sponsor
Deven Jadhav