### PR TITLE
add ops.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4261,6 +4261,12 @@ portal.parthenon:
 passport:
   type: CNAME
   value: 60edb94de5050d99.vercel-dns-016.com.
+patch: #leo@hackclub.com U07BLJ1MBEE
+  octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
+  value: a.selfhosted.hackclub.com.
 pathfinder:
   ttl: 300
   type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4122,6 +4122,10 @@ opensauce-leaderboard: # zach@hackclub.com
   ttl: 300
   type: CNAME
   value: a.limited.selfhosted.hackclub.com.
+ops: # leo@hackclub.com U07BLJ1MBEE
+  ttl: 300
+  type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 orchard: #tongyu@hackclub.com U07DJMFAQQP
 - octodns:
     cloudflare:

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -37,6 +37,7 @@
   - apple-domain-verification=Kq0tydhcBoM2dHTX   # gary@hackclub.com (Apple Business Manager)
   - MS=ms66267035
   - facebook-domain-verification=z5cyjpqj1fvx5315wk3ahnkx4ohi6r
+  - facebook-domain-verification=n1zcixmsek4ujgvgkxd65dlhien1lk
   - anthropic-domain-verification-hkth5m=hheIAy80WjbR1ZRaKVlWYZ0Z6   # alex@hackclub.com / gary@hackclub.com
 44.74:
 - ttl: 300


### PR DESCRIPTION
Adds `ops.hackclub.com` as a CNAME to `a.ingress.tier2.infra.hackclub.com.`

Contact: leo@hackclub.com (U07BLJ1MBEE)