### PR TITLE
Adding liquidate.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3738,6 +3738,9 @@ links: # leo@hackclub.com U07BLJ1MBEE
 linkscape:
   type: CNAME
   value: cname.vercel-dns.com.
+liquidate: # U083W5CCFDG joaquin@hackclub.com
+  type: CNAME
+  value: a.selfhosted.hackclub.com
 list:
   type: TXT
   value: google-site-verification=dy5FQ7euw6ZutiApm5ZdCTUgWn9CL3uhfJWHfD3TxLk


### PR DESCRIPTION


# Adding `liquidate.hackclub.com`

## Description of changes
Adding the Liquidate subdomain to be redirected with Redirectorizer

## Website content/purpose
Redirects to the itch.io game jam Max H and I are running

## HQ Sponsor
Me!

you can hit the quan a little bit