### PR TITLE
Add Ari webhooks subdomain service

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -671,6 +671,12 @@ ari: # nathan@hackclub.com
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
+webhooks.ari: # nathan@hackclub.com
+  octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 armed:
 - octodns:
     cloudflare:


### PR DESCRIPTION
# Adding `webhooks.ari.hackclub.com`

## Description of changes
Adding the subdomain for the service worker in Ari to DNS

## Website content/purpose
Service worker for ari.hackclub.com

## HQ Sponsor
@notaroomba 
