### PR TITLE
Updating `anvil.hackclub.com`

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -590,7 +590,10 @@ angelhacksto:
   type: CNAME
   value: cname.vercel-dns.com.
 anvil: # ascpixi@hackclub.com U082DPCGPST
-- ttl: 300
+  octodns:
+    cloudflare:
+      proxied: true
+  ttl: 300
   type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
 apacdirectory:


### PR DESCRIPTION
# Updating `anvil.hackclub.com`

## Description of changes
Enables Cloudflare proxying on the existing `anvil.hackclub.com` CNAME by adding `octodns.cloudflare.proxied: true` (mirroring the `api2` record's config). The record currently has no `proxied` flag, so it resolves DNS-only (grey cloud) straight to the tier2 ingress origin — every request pays the full origin RTT plus a fresh TCP+TLS handshake (~3× RTT on cold connections, measured ~360–500ms). Proxying terminates TLS at a nearby Cloudflare edge and reuses warm connections to origin, which should cut request latency substantially.

No change to the CNAME target, type, or TTL — only the proxy flag.

```diff
 anvil: # ascpixi@hackclub.com U082DPCGPST
-- ttl: 300
+  octodns:
+    cloudflare:
+      proxied: true
+  ttl: 300
   type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
```

## Website content/purpose
Not a new subdomain — `anvil.hackclub.com` is an existing, live YSWS app (Anvil) hosted on Orchard. This PR only changes how its traffic is routed.

## HQ Sponsor
N/A — existing subdomain, no new allocation. (Record owner: @ascpixi, ascpixi@hackclub.com)
