### PR TITLE
Add ru.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4980,6 +4980,9 @@ rrhs:
 rss:
   type: CNAME
   value: 5e3aec56f7ee6698.vercel-dns-016.com.
+ru: # developer.vladislav.smirnov@gmail.com U092K4W1ZB2
+  type: CNAME
+  value: a05569dabb46ea5b.vercel-dns-016.com.
 runshaw:
   type: CNAME
   value: danielb.hackclub.app.


### PR DESCRIPTION
# Adding `ru.hackclub.com`

## Description of changes
Adding a CNAME record for `ru.hackclub.com` pointing to the [hackclub/global](https://github.com/hackclub/global) localization project.

## Website content/purpose
Localized Russian version of the Hack Club homepage, following the same format as other language subdomains (e.g., `fr.hackclub.com`). The translation (`ru.ts`) is ready and will be submitted once this DNS PR is merged.

## HQ Sponsor
N/A