### PR TITLE
Add waypoint YSWS

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -6223,6 +6223,10 @@ wormhole:
   ttl: 300
   type: CNAME
   value: tggocccwo0oogs4wk8swgwkg.a.selfhosted.hackclub.com.
+waypoint: # contactloganpeterson@gmail.com U079WLY0HLY
+- ttl: 300
+  type: CNAME
+  value: waypoint.loganpeterson.org.
 wshackclub:
 - ttl: 300
   type: A
@@ -6279,7 +6283,3 @@ zwp:
 - ttl: 300
   type: A
   value: 172.99.233.117
-waypoint:
-- ttl: 300
-  type: CNAME
-  value: waypoint.loganpeterson.org.

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -6279,4 +6279,7 @@ zwp:
 - ttl: 300
   type: A
   value: 172.99.233.117
-
+waypoint:
+- ttl: 300
+  type: CNAME
+  value: waypoint.loganpeterson.org.

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -6129,6 +6129,10 @@ waveband:
 waveform: # echo@hackclub.com U080A3QP42C
   type: CNAME
   value: a252d1919bee0034.vercel-dns-016.com.
+waypoint: # contactloganpeterson@gmail.com U079WLY0HLY
+- ttl: 300
+  type: CNAME
+  value: waypoint.loganpeterson.org.
 webdev: # lynn@hackclub.com U07ULNFPQ4T
   type: CNAME
   value: 7d8a0b8aac5ada06.vercel-dns-016.com.
@@ -6223,10 +6227,6 @@ wormhole:
   ttl: 300
   type: CNAME
   value: tggocccwo0oogs4wk8swgwkg.a.selfhosted.hackclub.com.
-waypoint: # contactloganpeterson@gmail.com U079WLY0HLY
-- ttl: 300
-  type: CNAME
-  value: waypoint.loganpeterson.org.
 wshackclub:
 - ttl: 300
   type: A


### PR DESCRIPTION
# [Adding] `waypoint.[hackclub.com]`

## Description of changes
Added Waypoint YSWS into DNS. The current implementation resolves to the github pages instead of vercel.

## Website content/purpose
This website serves as the main draw + guides for the Waypoint YSWS! At the time of the PR this is likely still at https://waypoint.loganpeterson.org/ though I am working to move it over.

## HQ Sponsor
Zach Latta
