### PR TITLE
Adding `99.hackclub.com`

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -43,6 +43,10 @@
 - ttl: 300
   type: CNAME
   value: cname.vercel-dns.com.
+99: # jeremy@hackclub.com U06UYA5GMB5
+- ttl: 300
+  type: CNAME
+  value: 8f031bee70d56e7e.vercel-dns-016.com.
 72f724f0383247cd44371eb3cf8102a1:
   ttl: 300
   type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -43,14 +43,14 @@
 - ttl: 300
   type: CNAME
   value: cname.vercel-dns.com.
-99: # jeremy@hackclub.com U06UYA5GMB5
-- ttl: 300
-  type: CNAME
-  value: 8f031bee70d56e7e.vercel-dns-016.com.
 72f724f0383247cd44371eb3cf8102a1:
   ttl: 300
   type: CNAME
   value: verify.bing.com.
+99: # jeremy@hackclub.com U06UYA5GMB5
+- ttl: 300
+  type: CNAME
+  value: 8f031bee70d56e7e.vercel-dns-016.com.
 2020-summer: # echo@hackclub.com U080A3QP42C
   type: CNAME
   value: d1a0b01afc6cee8c.vercel-dns-016.com.


### PR DESCRIPTION
# Adding `99.hackclub.com`

## Description of changes
Adding the domain `99.hackclub.com` pointed at the HC vercel

## Website content/purpose
This is the website for Like It's 1999, see https://like-its-1999.hackclub.dev/

## HQ Sponsor
I [Jeremy](https://hackclub.enterprise.slack.com/team/U06UYA5GMB5) am sponsoring this