### PR TITLE
Add portputer subdomain

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4010,6 +4010,9 @@ portalvr:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
+portputer: # lola@hackclub.com
+- type: CNAME
+  value: portputer.milkcool.ru.
 postal:
   type: CNAME
   value: postal.servers.hackclub.com.


### PR DESCRIPTION
Adding portputer.hackclub.com

adding portputer.hackclub.com to dns. sponsored by lola sanchez at hack club, and community member lily the milk cool on slack. 

2 week long ysws until July 28th - spend 6 hours coding, get a cardputer.
