### PR TITLE
Add portputer subdomain

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4012,7 +4012,7 @@ portalvr:
   value: a.selfhosted.hackclub.com.
 portputer: # lola@hackclub.com
 - type: CNAME
-  value: portputer-4q3oq922h.hackclub.dev.
+  value: 18c5a97b962d72ed.vercel-dns-013.com.
 postal:
   type: CNAME
   value: postal.servers.hackclub.com.

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4010,6 +4010,9 @@ portalvr:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
+portputer: # lola@hackclub.com
+- type: CNAME
+  value: portputer-4q3oq922h.hackclub.dev.
 postal:
   type: CNAME
   value: postal.servers.hackclub.com.


### PR DESCRIPTION
Adds `portputer.hackclub.com` as a CNAME to `portputer-4q3oq922h.hackclub.dev.`
github pages does not like new domains so changing over to vercel!

Contact: lola@hackclub.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)