### PR TITLE
Moving webhooks.ari to Server A from Orchard

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -606,7 +606,7 @@ webhooks.ari: # nathan@hackclub.com
     cloudflare:
       proxied: true
   type: CNAME
-  value: a.ingress.tier2.infra.hackclub.com.
+  value: a.selfhosted.hackclub.com.
 armed:
 - octodns:
     cloudflare:


### PR DESCRIPTION
<!--
This is a template, please modify it to fit your Pull Request. 

Please pick one option when multiple are presented in brackets.

Please title your PR like this: [Adding/Deleting/Updating] `subdomain.[hackclub.com/dino.icu/etc]`
-->

# Updating `webhooks.ari.hackclub.com`

## Description of changes
Moving the Ari Webhooks service from Orchard to Coolify due to resource limitations that prevent the worker to function properly.

## Website content/purpose
Background Worker Endpoint

## HQ Sponsor
@notaroomba 