### PR TITLE
Remove clubs.hackclub.com CNAME (1/2, prep for ALIAS + email records)

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1328,12 +1328,6 @@ clubdash:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
-clubs: # dhyan@hackclub.com // U0824G9PTFE
-- octodns:
-    cloudflare:
-      proxied: true
-  type: CNAME
-  value: a.ingress.tier2.infra.hackclub.com.
 clubsite: #jared@hackclub.com U07HEH4N8UV
 - type: CNAME
   value: a4c912838eb0ecb4.vercel-dns-016.com.


### PR DESCRIPTION
Deletes the `clubs` CNAME so it can be re-added as an `ALIAS` alongside new email records in a follow-up PR, per the README's process for replacing a CNAME with another record type (same approach as #1642/#1643).

**Merge order:** this PR must be merged first; the follow-up PR re-adds `clubs` (same target, still proxied) plus Resend DKIM/SPF/MX records. Please merge the follow-up immediately after this one so `clubs.hackclub.com` isn't left without a record.

Contact: dhyan@hackclub.com // U0824G9PTFE

🤖 Generated with [Claude Code](https://claude.com/claude-code)