### PR TITLE
Add record for unfold.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5333,6 +5333,12 @@ undercity:
 underground:
 - type: CNAME
   value: carrotsoups.github.io.
+unfold: # jenin@hackclub.com
+- octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 uptime:
 - octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @jeninh via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
unfold: # jenin@hackclub.com
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `jenin@hackclub.com`

Please review carefully before merging.
