### PR TITLE
Update record for libreassistant.dino.icu

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -816,7 +816,7 @@ library: # koy@camerini.me U0ALZQ9FP9P
 
 libreassistant: # mostlime@outlook.com
 - type: CNAME
-  value: libreassistant.mostlime.hackclub.app.
+  value: mostlime.hackclub.app.
 lkmw:
   ttl: 600
   type: CNAME


### PR DESCRIPTION
## DNS Editor submission

Opened by @Mostlime12195 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME libreassistant.mostlime.hackclub.app.` under `libreassistant.dino.icu`.

### Updated record
```yaml
libreassistant: # mostlime@outlook.com
- type: CNAME
  value: mostlime.hackclub.app.
```

Contact: `mostlime@outlook.com`

Please review carefully before merging.
