### PR TITLE
Update record for lyla.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3265,12 +3265,12 @@ low-skies:
 luna:
   type: CNAME
   value: cname.vercel-dns.com.
-lyla: # U054VC2KM9P / U06EMBJH71S / U06UYA5GMB5 (amber/lou/jeremy)
+lyla: # dracula@conduct.hackclub.com U0A5PLKMB25
 - octodns:
     cloudflare:
       proxied: true
   type: CNAME
-  value: a.selfhosted.hackclub.com.
+  value: a.ingress.tier2.infra.hackclub.com.
 macondo: # nathan@hackclub.com
   octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @0xDracula via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME a.selfhosted.hackclub.com.` under `lyla.hackclub.com`.

### Updated record
```yaml
lyla: # dracula@conduct.hackclub.com U0A5PLKMB25
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `dracula@conduct.hackclub.com U0A5PLKMB25`

Please review carefully before merging.
