### PR TITLE
Add record for shroud.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4614,6 +4614,12 @@ send.shop: # rushil@hackclub.com U020X4GCWSF
 showcase:
   type: CNAME
   value: onboard-7w9.pages.dev.
+shroud: # dracula@conduct.hackclub.com U0A5PLKMB25
+- octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 shush:
   octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @0xDracula via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
shroud: # dracula@conduct.hackclub.com U0A5PLKMB25
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `dracula@conduct.hackclub.com U0A5PLKMB25`

Please review carefully before merging.
