### PR TITLE
Add record for imafurry.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2878,6 +2878,12 @@ ihs:
 illumination:
 - type: CNAME
   value: 0b4e7cc575f0aff2.vercel-dns-017.com.
+imafurry: # U08PD2ZB3DL
+- octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
+  value: a.selfhosted.hackclub.com.
 imperial:
   type: CNAME
   value: ihs-hacklab.github.io.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
imafurry: # U08PD2ZB3DL
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.selfhosted.hackclub.com.
```

Contact: `U08PD2ZB3DL`

Please review carefully before merging.
