### PR TITLE
Update record for uwu.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5351,12 +5351,9 @@ ur:
 url75: # SendGrid Sender Authentication (bank@hackclub.com)
   type: CNAME
   value: sendgrid.net.
-uwu: # nathan@hackclub.com U05EZRFKRV4
-  octodns:
-    cloudflare:
-      proxied: true
-  type: CNAME
-  value: a.selfhosted.hackclub.com.
+uwu: # U08PD2ZB3DL
+- type: CNAME
+  value: cname.vercel-dns.com.
 v2:
 - type: CNAME
   value: cname.vercel-dns.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME a.selfhosted.hackclub.com.` under `uwu.hackclub.com`.

### Updated record
```yaml
uwu: # U08PD2ZB3DL
- type: CNAME
  value: cname.vercel-dns.com.
```

Contact: `U08PD2ZB3DL`

Please review carefully before merging.
