### PR TITLE
Adding convert3d.dino.icu

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1470,6 +1470,10 @@ convert: # @msw max@hackclub.com — migrated to Orchard
       proxied: true
   type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
+  convert3d:
+  - type: CNAME
+    value: planema4.hackclub.app.
+    ttl: 600
 convert-backend:
 - type: A
   value: 104.36.86.12


### PR DESCRIPTION
# Adding `convert3d.dino.icu`

## Description of changes

Adding the `convert3d.dino.icu` subdomain and pointing it to `planema4.hackclub.app`.

## Website content/purpose

This website will host a 3D model converter that allows users to upload 3D model files and convert them between supported formats.

## HQ Sponsor

Not applicable — this is a `dino.icu` subdomain.