### PR TITLE
Delete record for it.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3017,9 +3017,6 @@ island:
 isthackers:
 - type: CNAME
   value: isthackers.github.io.
-it:
-  type: CNAME
-  value: a05569dabb46ea5b.vercel-dns-016.com.
 italia:
   type: A
   value: 185.151.30.185


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME a05569dabb46ea5b.vercel-dns-016.com.` under `it.hackclub.com`.

Please review carefully before merging.
