### PR TITLE
Delete record for de.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1620,9 +1620,6 @@ vote.daydream:
 daysofservice:
   type: CNAME
   value: 84733497b6deb720.vercel-dns-016.com.
-de:
-  type: CNAME
-  value: a05569dabb46ea5b.vercel-dns-016.com.
 dear-joe:
 - type: CNAME
   value: f888ad30fdf5a183.vercel-dns-016.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME a05569dabb46ea5b.vercel-dns-016.com.` under `de.hackclub.com`.

Please review carefully before merging.
