### PR TITLE
Delete record for vi.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5384,9 +5384,6 @@ veil:
 india.verifications:
 - type: CNAME
   value: bbd7d5a21981de37.vercel-dns-016.com.
-vi:
-  type: CNAME
-  value: a05569dabb46ea5b.vercel-dns-016.com.
 vibes: # jared@hackclub.com / lynn@hackclub.com
   type: CNAME
   value: b18296b83a87e452.vercel-dns-016.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME a05569dabb46ea5b.vercel-dns-016.com.` under `vi.hackclub.com`.

Please review carefully before merging.
