### PR TITLE
Delete record for rw.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4344,9 +4344,6 @@ ru: # echo@hackclub.com
 runshaw:
   type: CNAME
   value: danielb.hackclub.app.
-rw:
-  type: CNAME
-  value: a05569dabb46ea5b.vercel-dns-016.com.
 sa:
   type: CNAME
   value: hc-sa.netlify.app.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME a05569dabb46ea5b.vercel-dns-016.com.` under `rw.hackclub.com`.

Please review carefully before merging.
