### PR TITLE
Delete record for fa.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1981,9 +1981,6 @@ extensify:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
-fa:
-  type: CNAME
-  value: a05569dabb46ea5b.vercel-dns-016.com.
 fab:
 - type: CNAME
   value: cname.vercel-dns.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME a05569dabb46ea5b.vercel-dns-016.com.` under `fa.hackclub.com`.

Please review carefully before merging.
