### PR TITLE
Delete record for tr.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5252,9 +5252,6 @@ touch-grass:
 toybox:
   type: CNAME
   value: d7ce54e48ab125e2.vercel-dns-016.com.
-tr:
-  type: CNAME
-  value: a05569dabb46ea5b.vercel-dns-016.com.
 trace: # aarav@fraud.land U07UK4S94KC
   type: CNAME
   value: 53547cd5ddd28c7e.vercel-dns-016.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME a05569dabb46ea5b.vercel-dns-016.com.` under `tr.hackclub.com`.

Please review carefully before merging.
