### PR TITLE
Delete record for _vercel.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -329,7 +329,6 @@ _vercel: #
   - "vc-domain-verify=waveband.hackclub.com,11dbb017182f655585ef"
   - "vc-domain-verify=wonderland-launch.hackclub.com,2a724b908654f2912e48"
   - "vc-domain-verify=wonderland.hackclub.com,0c2e35e271cd0c23752d"
-  - "vc-domain-verify=woof.hackclub.com,576b3b21721743d2f9f9"
   - "vc-domain-verify=calculate.hackclub.com,2b76d639c0c04dc6b191"
   - "vc-domain-verify=premiere.hackclub.com,8abf79e779dd433fe3d4"
   - "vc-domain-verify=whimsy.hackclub.com,712b4c3c244883005c42"


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `TXT vc-domain-verify=woof.hackclub.com,576b3b21721743d2f9f9` under `_vercel.hackclub.com`.

Please review carefully before merging.
