### PR TITLE
Update clubs.hackclub.com for email support

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1328,6 +1328,27 @@ clubdash:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
+clubs: # dhyan@hackclub.com // U0824G9PTFE
+- octodns:
+    lenient: true
+    cloudflare:
+      proxied: true
+  type: ALIAS
+  value: a.ingress.tier2.infra.hackclub.com.
+- type: MX
+  value:
+    exchange: inbound-smtp.us-east-1.amazonaws.com.
+    preference: 10
+resend._domainkey.clubs: # dhyan@hackclub.com // U0824G9PTFE
+  type: TXT
+  value: "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC7NaUrPsTNbDNJjkzvoItciTUCgN+JF6SnvCejjyGGuM6skFCbUeeXyCcHE8lNEfcAUdexEoSlGYGGUxvgyOHb10zEm+tezjIaN3s22+LXBCZqPfzyOVBBoeahRqMEn49jnV3Z+zPW5ki4YM0sCmAWvcW8KXhixaOujcO6yhHcxwIDAQAB"
+send.clubs: # dhyan@hackclub.com // U0824G9PTFE
+- type: MX
+  value:
+    exchange: feedback-smtp.us-east-1.amazonses.com.
+    preference: 10
+- type: TXT
+  value: "v=spf1 include:amazonses.com ~all"
 clubsite: #jared@hackclub.com U07HEH4N8UV
 - type: CNAME
   value: a4c912838eb0ecb4.vercel-dns-016.com.

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1328,12 +1328,6 @@ clubdash:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
-clubs: # dhyan@hackclub.com // U0824G9PTFE
-- octodns:
-    cloudflare:
-      proxied: true
-  type: CNAME
-  value: a.ingress.tier2.infra.hackclub.com.
 clubsite: #jared@hackclub.com U07HEH4N8UV
 - type: CNAME
   value: a4c912838eb0ecb4.vercel-dns-016.com.

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1326,7 +1326,7 @@ clubdash:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
-clubs: # dhyan@hackclub.com // U0824G9PTFE
+clubs: # dhyan@hackclub.com U0824G9PTFE
 - octodns:
     lenient: true
     cloudflare:
@@ -1337,10 +1337,10 @@ clubs: # dhyan@hackclub.com // U0824G9PTFE
   value:
     exchange: inbound-smtp.us-east-1.amazonaws.com.
     preference: 10
-resend._domainkey.clubs: # dhyan@hackclub.com // U0824G9PTFE
+resend._domainkey.clubs: # dhyan@hackclub.com U0824G9PTFE
   type: TXT
   value: "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC7NaUrPsTNbDNJjkzvoItciTUCgN+JF6SnvCejjyGGuM6skFCbUeeXyCcHE8lNEfcAUdexEoSlGYGGUxvgyOHb10zEm+tezjIaN3s22+LXBCZqPfzyOVBBoeahRqMEn49jnV3Z+zPW5ki4YM0sCmAWvcW8KXhixaOujcO6yhHcxwIDAQAB"
-send.clubs: # dhyan@hackclub.com // U0824G9PTFE
+send.clubs: # dhyan@hackclub.com U0824G9PTFE
 - type: MX
   value:
     exchange: feedback-smtp.us-east-1.amazonses.com.


### PR DESCRIPTION
The CNAME must be deleted in a separate PR before it can be replaced
with an ALIAS + email records, per the process described in the README.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com><!--
This is a template, please modify it to fit your Pull Request. 

Please pick one option when multiple are presented in brackets.

Please title your PR like this: [Adding/Deleting/Updating] `subdomain.[hackclub.com/dino.icu/etc]`
-->

# [Updating] `clubs.hackclub.com`

## Description of changes
<!-- Provide a description of the changes you are making. -->
adding email support via resend
## Website content/purpose
<!-- If you are adding a new subdomain, provide a quick description of the content/purpose of the website you plan to host. -->

## HQ Sponsor
<!-- If you are requesting a subdomain under `hackclub.com`, please state the name of your hq POC/sponsor: -->
myself
