### PR TITLE
Add record for nemo.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3525,6 +3525,12 @@ express.neighborhood:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
+nemo: # dracula@conduct.hackclub.com U0A5PLKMB25
+- octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 neohack:
   type: CNAME
   value: 10f7be41618be21d.vercel-dns-016.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @0xDracula via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
nemo: # dracula@conduct.hackclub.com U0A5PLKMB25
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `dracula@conduct.hackclub.com U0A5PLKMB25`

Please review carefully before merging.
