### PR TITLE
Delete record for ur.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5356,9 +5356,6 @@ uptime:
       proxied: true
   type: CNAME
   value: uptime.selfhosted.hackclub.com.
-ur:
-  type: CNAME
-  value: a05569dabb46ea5b.vercel-dns-016.com.
 url75: # SendGrid Sender Authentication (bank@hackclub.com)
   type: CNAME
   value: sendgrid.net.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME a05569dabb46ea5b.vercel-dns-016.com.` under `ur.hackclub.com`.

Please review carefully before merging.
