### PR TITLE
Delete record for bn.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -965,9 +965,6 @@ badge.blueprint: # U06CRF4DLSU
 - ttl: 600
   type: CNAME
   value: mpkendall.github.io.
-bn:
-  type: CNAME
-  value: a05569dabb46ea5b.vercel-dns-016.com.
 boba:
 - type: CNAME
   value: hackclub.github.io.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME a05569dabb46ea5b.vercel-dns-016.com.` under `bn.hackclub.com`.

Please review carefully before merging.
