### PR TITLE
Delete record for pl.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3940,9 +3940,6 @@ pinetree:
 pixeldust:
   type: CNAME
   value: cname.vercel-dns.com.
-pl:
-  type: CNAME
-  value: a05569dabb46ea5b.vercel-dns-016.com.
 plausible: # @msw max@hackclub.com
   type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME a05569dabb46ea5b.vercel-dns-016.com.` under `pl.hackclub.com`.

Please review carefully before merging.
