### PR TITLE
Delete record for thai.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5148,9 +5148,6 @@ tfss:
 - type: TXT
   values:
   - v=spf1 include:spf.improvmx.com ~all
-thai:
-  type: CNAME
-  value: a05569dabb46ea5b.vercel-dns-016.com.
 the-pier:
 - type: A
   value: 178.156.170.71


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME a05569dabb46ea5b.vercel-dns-016.com.` under `thai.hackclub.com`.

Please review carefully before merging.
