### PR TITLE
Delete record for kr.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3151,9 +3151,6 @@ knit:
 ko:
   type: CNAME
   value: cname.vercel-dns.com.
-kr:
-  type: CNAME
-  value: a05569dabb46ea5b.vercel-dns-016.com.
 lambert:
   type: CNAME
   value: lambert-hackclub.vercel.app.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME a05569dabb46ea5b.vercel-dns-016.com.` under `kr.hackclub.com`.

Please review carefully before merging.
