### PR TITLE
Add DNS record: stays.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4956,6 +4956,9 @@ status: # echo@hackclub.com U080A3QP42C
   octodns:
     cloudflare:
       proxied: true
+stays: # leo@hackclub.com
+  type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 steelyard: # mattsoh@hackclub.com U07DPHQCCCS
   type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.


### PR DESCRIPTION
Adds `stays.hackclub.com` as a CNAME to `a.ingress.tier2.infra.hackclub.com.`