### PR TITLE
Delete record for jp.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3088,9 +3088,6 @@ journey:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
-jp:
-  type: CNAME
-  value: a05569dabb46ea5b.vercel-dns-016.com.
 jpeg:
 - type: CNAME
   value: cname.vercel-dns.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME a05569dabb46ea5b.vercel-dns-016.com.` under `jp.hackclub.com`.

Please review carefully before merging.
