### PR TITLE
Delete record for pa.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3817,9 +3817,6 @@ ows: #outernet-web-services
 p2p:
   type: CNAME
   value: p2phackclub.github.io.
-pa:
-  type: CNAME
-  value: a05569dabb46ea5b.vercel-dns-016.com.
 pack:
   type: CNAME
   value: 6ac58e3a94296079.vercel-dns-016.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME a05569dabb46ea5b.vercel-dns-016.com.` under `pa.hackclub.com`.

Please review carefully before merging.
