### PR TITLE
Delete record for hi.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2759,9 +2759,6 @@ hermes:
 hersey:
 - type: CNAME
   value: cname.vercel-dns.com.
-hi:
-  type: CNAME
-  value: a05569dabb46ea5b.vercel-dns-016.com.
 high-seas:
 - type: CNAME
   value: 992022aa5b4ad559.vercel-dns-016.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME a05569dabb46ea5b.vercel-dns-016.com.` under `hi.hackclub.com`.

Please review carefully before merging.
