### PR TITLE
Add sunboard CNAME record to hackclub.com.yaml

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5043,6 +5043,9 @@ summit:
 sunbeam: # reem@hackclub.com
   type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
+sunboard: # lola@hackclub.com
+  type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 suncatcher: # U0943NG73PA julia@hackclub.com
   type: CNAME
   value: suncatcher-6owl6r1ft.hackclub.dev.


### PR DESCRIPTION
adding record for sunboard, a slack bot showing the leaderboard of signups for sunbeam, points to orchard and is under sunbeam orchard project

lola@hackclub.com