### PR TITLE
Delete record for ctf.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1548,9 +1548,6 @@ css:
 css-starter:
   type: CNAME
   value: 76b3c318aa347add.vercel-dns-016.com.
-ctf:
-- type: CNAME
-  value: zealous-booth-dc1397.netlify.app.
 portal.ctf:
   type: A
   value: 167.99.110.64


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME zealous-booth-dc1397.netlify.app.` under `ctf.hackclub.com`.

Please review carefully before merging.
