### PR TITLE
Delete record for portal.ctf.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1551,9 +1551,6 @@ css-starter:
 ctf:
 - type: CNAME
   value: zealous-booth-dc1397.netlify.app.
-portal.ctf:
-  type: A
-  value: 167.99.110.64
 ctrl-alt-tec:
 - type: CNAME
   value: ctrl-alt-tec.github.io.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `A 167.99.110.64` under `portal.ctf.hackclub.com`.

Please review carefully before merging.
