### PR TITLE
Move kyto to kyto.dino.icu

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -428,11 +428,6 @@ hcai.devansh: # devansh.awat@gmail.com https://github.com/Devansh-awat
   type: A
   value: 140.245.203.110
 
-kyto.devansh: # devansh.awat@gmail.com https://github.com/Devansh-awat
-- ttl: 600
-  type: A
-  value: 140.245.203.110
-
 stardance.devansh: # devansh.awat@gmail.com https://github.com/Devansh-awat
 - ttl: 600
   type: A
@@ -812,6 +807,11 @@ kunal: # kunal
   values:
   - ns1.vercel-dns.com.
   - ns2.vercel-dns.com.
+
+kyto: # devansh.awat@gmail.com https://github.com/Devansh-awat
+- ttl: 600
+  type: A
+  value: 140.245.203.110
 
 la: # Laker Turner's links page - @lxjv or @la / @laker in the slack
   ttl: 600


### PR DESCRIPTION
Moves my kyto record from `kyto.devansh.dino.icu` to `kyto.dino.icu` (points at the same Oracle host). Follow-up to #3217.