### PR TITLE
Update record for fallout.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2001,12 +2001,12 @@ fab:
 editor.fab:
   type: CNAME
   value: cname.vercel-dns.com.
-fallout: # samliu@hackclub.com
-  octodns:
+fallout: # U08PD2ZB3DL
+- octodns:
     cloudflare:
       proxied: true
   type: CNAME
-  value: ingress.lfdl.ink.
+  value: a.selfhosted.hackclub.com.
 lab.fallout: # enigmaticprojectorpheus@proton.me
   octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME ingress.lfdl.ink.` under `fallout.hackclub.com`.

### Updated record
```yaml
fallout: # U08PD2ZB3DL
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.selfhosted.hackclub.com.
```

Contact: `U08PD2ZB3DL`

Please review carefully before merging.
