### PR TITLE
Update record for fallout.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2001,12 +2001,12 @@ fab:
 editor.fab:
   type: CNAME
   value: cname.vercel-dns.com.
-fallout: # U08PD2ZB3DL
+fallout: # samliu@hackclub.com
 - octodns:
     cloudflare:
       proxied: true
   type: CNAME
-  value: a.ingress.tier2.infra.hackclub.com.
+  value: a.selfhosted.hackclub.com.
 lab.fallout: # enigmaticprojectorpheus@proton.me
   octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME a.ingress.tier2.infra.hackclub.com.` under `fallout.hackclub.com`.

### Updated record
```yaml
fallout: # samliu@hackclub.com
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.selfhosted.hackclub.com.
```

Contact: `samliu@hackclub.com`

Please review carefully before merging.
