### PR TITLE
Add record for hall-of-fame.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2566,6 +2566,9 @@ haj4ever: # Rupnil Codes (rupnil.mondal2+hackclub@gmail.com; slack: U0A4UTULSLE)
       proxied: true
   type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
+hall-of-fame: # mattsoh@hackclub.com U07DPHQCCCS
+- type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 halo:
   type: CNAME
   value: c408328a709a38b2.vercel-dns-016.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @mattsoh via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
hall-of-fame: # mattsoh@hackclub.com U07DPHQCCCS
- type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `mattsoh@hackclub.com U07DPHQCCCS`

Please review carefully before merging.
