### PR TITLE
Update record for draw-dino.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1731,9 +1731,12 @@ downscale: # augie@hackclub.com
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
-draw-dino: # josias@hackclub.com U01PJ08PR7S & hc+dns@matmanna.dev U07VA44DNBA
+draw-dino: # mattsoh@hackclub.com U07DPHQCCCS
+- octodns:
+    cloudflare:
+      proxied: true
   type: CNAME
-  value: b.selfhosted.hackclub.com
+  value: a.ingress.tier2.infra.hackclub.com.
 drive:
   type: CNAME
   value: ghs.googlehosted.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @mattsoh via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME b.selfhosted.hackclub.com` under `draw-dino.hackclub.com`.

### Updated record
```yaml
draw-dino: # mattsoh@hackclub.com U07DPHQCCCS
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `mattsoh@hackclub.com U07DPHQCCCS`

Please review carefully before merging.
