### PR TITLE
Update record for hall-of-fame.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2567,7 +2567,10 @@ haj4ever: # Rupnil Codes (rupnil.mondal2+hackclub@gmail.com; slack: U0A4UTULSLE)
   type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
 hall-of-fame: # mattsoh@hackclub.com U07DPHQCCCS
-- type: CNAME
+- octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
 halo:
   type: CNAME


### PR DESCRIPTION
## DNS Editor submission

Opened by @mattsoh via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME a.ingress.tier2.infra.hackclub.com.` under `hall-of-fame.hackclub.com`.

### Updated record
```yaml
hall-of-fame: # mattsoh@hackclub.com U07DPHQCCCS
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `mattsoh@hackclub.com U07DPHQCCCS`

Please review carefully before merging.
