### PR TITLE
Update record for steelyard.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4969,6 +4969,9 @@ stays: # leo@hackclub.com
   type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
 steelyard: # mattsoh@hackclub.com U07DPHQCCCS
+- octodns:
+    cloudflare:
+      proxied: true
   type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
 steelyard-local: # mattsoh@hackclub.com U07DPHQCCCS


### PR DESCRIPTION
## DNS Editor submission

Opened by @mattsoh via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME a.ingress.tier2.infra.hackclub.com.` under `steelyard.hackclub.com`.

### Updated record
```yaml
steelyard: # mattsoh@hackclub.com U07DPHQCCCS
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `mattsoh@hackclub.com U07DPHQCCCS`

Please review carefully before merging.
