### PR TITLE
Update record for steelyard-local.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4972,6 +4972,9 @@ steelyard: # mattsoh@hackclub.com U07DPHQCCCS
   type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
 steelyard-local: # mattsoh@hackclub.com U07DPHQCCCS
+- octodns:
+    cloudflare:
+      proxied: true
   type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
 stemegypt:


### PR DESCRIPTION
## DNS Editor submission

Opened by @mattsoh via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME a.ingress.tier2.infra.hackclub.com.` under `steelyard-local.hackclub.com`.

### Updated record
```yaml
steelyard-local: # mattsoh@hackclub.com U07DPHQCCCS
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `mattsoh@hackclub.com U07DPHQCCCS`

Please review carefully before merging.
