### PR TITLE
Delete record for earlybird.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1761,9 +1761,6 @@ dummies:
 dv:
   type: CNAME
   value: cname.vercel-dns.com.
-earlybird:
-  type: CNAME
-  value: early-bird-hackclub.netlify.com.
 easel:
   type: CNAME
   value: 46c19d5618208b3e.vercel-dns-016.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME early-bird-hackclub.netlify.com.` under `earlybird.hackclub.com`.

Please review carefully before merging.
