### PR TITLE
Update record for sidekick.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4641,6 +4641,9 @@ shush:
   type: CNAME
   value: a.selfhosted.hackclub.com.
 sidekick: # ascpixi@hackclub.com U082DPCGPST
+- octodns:
+    cloudflare:
+      proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
 sidequests:


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME a.selfhosted.hackclub.com.` under `sidekick.hackclub.com`.

### Updated record
```yaml
sidekick: # ascpixi@hackclub.com U082DPCGPST
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.selfhosted.hackclub.com.
```

Contact: `ascpixi@hackclub.com U082DPCGPST`

Please review carefully before merging.
