### PR TITLE
Adding smol.hackclub.com + in-synch.smol.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4898,6 +4898,12 @@ smelt:
 smhs:
   type: CNAME
   value: zephyril.github.io.
+smol: # arcadewise@hackclub.com
+  type: CNAME
+  value: cd6da731c111c254.vercel-dns-013.com.
+in-synch.smol: # arcadewise@hackclub.com
+  type: CNAME
+  value: 437c8892af4826a1.vercel-dns-013.com.
 snake: # U07EB2Y76DP
 - type: CNAME
   value: yousnakewesnake.netlify.app.


### PR DESCRIPTION

# Adding smol.hackclub.com + in-synch.smol.hackclub.com

## Description of changes
Add both the domains

## Website content/purpose
A YSWS meta-platform, and the first program.

## HQ Sponsor
Myself, Arcade W.