### PR TITLE
Update record for webhooks.ari.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -585,11 +585,11 @@ ari: # nathan@hackclub.com
   type: CNAME
   value: a.selfhosted.hackclub.com.
 webhooks.ari: # nathan@hackclub.com
-  octodns:
+- octodns:
     cloudflare:
       proxied: true
   type: CNAME
-  value: a.ingress.tier2.infra.hackclub.com.
+  value: a.selfhosted.hackclub.com.
 armed:
 - octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @sbeltranc via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME a.ingress.tier2.infra.hackclub.com.` under `webhooks.ari.hackclub.com`.

### Updated record
```yaml
webhooks.ari: # nathan@hackclub.com
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.selfhosted.hackclub.com.
```

Contact: `nathan@hackclub.com`

Please review carefully before merging.
