### PR TITLE
Add record for startgrant.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5066,6 +5066,9 @@ staging.stardance: # kartikey@hackclub.com
 url1054.stardance: # kartikey@hackclub.com
   type: CNAME
   value: sendgrid.net.
+startgrant: # ivie@hackclub.com
+- type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 stasis: # @Jay U08AA6HA82F
 - ttl: 3600
   type: A


### PR DESCRIPTION
## DNS Editor submission

Opened by @Charmunks via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
startgrant: # ivie@hackclub.com
- type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `ivie@hackclub.com`

Please review carefully before merging.
