### PR TITLE
Update record for jobs.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3151,12 +3151,12 @@ jenin-mail: #jenin@hackclub.com
 jet:
 - type: CNAME
   value: 93403cee35b42da2.vercel-dns-016.com.
-jobs: # nora@hackclub.com U06QK6AG3RD
+jobs: # echo@hackclub.com U080A3QP42C
 - octodns:
     cloudflare:
       proxied: true
   type: CNAME
-  value: a.selfhosted.hackclub.com.
+  value: a.ingress.tier2.infra.hackclub.com.
 jolly: # jolly@hackclub.com U08CJCZ2Z9S
 - type: CNAME
   value: 07b89999ac9f4966.vercel-dns-016.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME a.selfhosted.hackclub.com.` under `jobs.hackclub.com`.

### Updated record
```yaml
jobs: # echo@hackclub.com U080A3QP42C
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `echo@hackclub.com U080A3QP42C`

Please review carefully before merging.
