### PR TITLE
Update record for jobs.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3156,7 +3156,7 @@ jobs: # echo@hackclub.com U080A3QP42C
     cloudflare:
       proxied: true
   type: CNAME
-  value: a.ingress.tier2.infra.hackclub.com.
+  value: b.selfhosted.hackclub.com.
 jolly: # jolly@hackclub.com U08CJCZ2Z9S
 - type: CNAME
   value: 07b89999ac9f4966.vercel-dns-016.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME a.ingress.tier2.infra.hackclub.com.` under `jobs.hackclub.com`.

### Updated record
```yaml
jobs: # echo@hackclub.com U080A3QP42C
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: b.selfhosted.hackclub.com.
```

Contact: `echo@hackclub.com U080A3QP42C`

Please review carefully before merging.
