### PR TITLE
Add record for nairobi.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3597,6 +3597,9 @@ mumble:
 muse:
   type: CNAME
   value: 78958f059c43551f.vercel-dns-016.com.
+nairobi: # harshilpatel5914@gmail.com      U06QMV51479
+- type: CNAME
+  value: cname.vercel-dns.com.
 ncssm:
   type: CNAME
   value: cname.vercel-dns.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @MastermindCore via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
nairobi: # harshilpatel5914@gmail.com      U06QMV51479
- type: CNAME
  value: c94332a0ceba2367.vercel-dns-017.com.
```

Contact: `harshilpatel5914@gmail.com      U06QMV51479`

Please review carefully before merging.
