### PR TITLE
Add whoami.dino.icu DNS record

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -1471,6 +1471,11 @@ weather:
   type: CNAME
   value: weathersomewhere.netlify.app.
 
+whoami: # cloudglides@proton.me U0A2EKA9FAL
+- ttl: 600
+  type: A
+  value: 216.198.79.1
+
 wikibase: # wikibase for the Hack Club community, to be managed by @recaptime-dev team through @ajhalili2006
   ttl: 600
   type: CNAME


### PR DESCRIPTION
Adding a DNS A record for `whoami.dino.icu` pointing to Vercel (216.198.79.1).

- Subdomain: whoami.dino.icu
- Record: A -> 216.198.79.1
- Contact: cloudglides@proton.me / U0A2EKA9FAL