### PR TITLE
Add record for docs.hcb.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2744,6 +2744,9 @@ blog.hcb: # HCB engineering/blog website
 changelog.hcb:
   type: CNAME
   value: headwayapp.co.
+docs.hcb: # alex@hackclub.com
+- type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 graph.hcb: # echo@hackclub.com U080A3QP42C
   type: CNAME
   value: a393a61874975956.vercel-dns-016.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @alexdevz via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
docs.hcb: # alex@hackclub.com
- type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `alex@hackclub.com`

internal team docs/notes (might be changed to different subdomain later)
