### PR TITLE
Point athena.hackclub.com at Orchard instead of Coolify

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -695,12 +695,12 @@ asw:
 asylum:
   type: CNAME
   value: cname.vercel-dns.com.
-athena:
+athena: # reem@hackclub.com — moved from Coolify to Orchard
 - octodns:
     cloudflare:
       proxied: true
   type: CNAME
-  value: a.selfhosted.hackclub.com.
+  value: a.ingress.tier2.infra.hackclub.com.
 award.athena:
 - octodns:
     cloudflare:


### PR DESCRIPTION
## Summary
- athena.hackclub.com is migrating from Coolify to Orchard
- Changes the CNAME target from `a.selfhosted.hackclub.com.` to `a.ingress.tier2.infra.hackclub.com.` — the same target `sunbeam` already uses
- Leaves `award.athena`, `awards.athena`, and `express.athena` untouched (separate apps, still on Coolify)

## Status
Opened as a draft — do **not** merge yet. The Orchard deployment (project `athena` in the YSWS org) is up and its build passes, but it's still missing a few env vars (`REVALIDATION_SECRET`, Airtable Events/General/Projects keys) and hasn't been verified end-to-end yet. Will mark ready for review once that's confirmed working.

## Test plan
- [ ] Set remaining env vars on the Orchard deployment
- [ ] Verify the site works fully on its temporary `*.k.hackclub.dev` URL
- [ ] Mark this PR ready for review and merge
- [ ] Confirm athena.hackclub.com resolves to Orchard and TLS is valid after merge
- [ ] Decommission the Coolify deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)