### PR TITLE
Add record for future.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2289,6 +2289,9 @@ fulfillment: #jenin@hackclub.com @jenin
 fusering:
   type: CNAME
   value: 71b1e2defbc1af44.vercel-dns-017.com.
+future: # antonio@hackclub.com
+- type: CNAME
+  value: d4aa17e03f291215.vercel-dns-013.com.
 gaither:
   type: CNAME
   value: gaither-hack-club.github.io.


### PR DESCRIPTION
## DNS Editor submission

Opened by @AD-Archer via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
future: # antonio@hackclub.com
- type: CNAME
  value: d4aa17e03f291215.vercel-dns-013.com.
```

Contact: `antonio@hackclub.com`

Please review carefully before merging.
