### PR TITLE
Delete record for _vercel.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -316,7 +316,6 @@ _vercel: #
   - "vc-domain-verify=saleh.hackclub.com,cdcc382c0ddbefe586b1"
   - "vc-domain-verify=simmer.hackclub.com,19a5cdf65fc7aedb7ccb"
   - "vc-domain-verify=southhighhack.hackclub.com,8cf484f7551780f58ae9"
-  - "vc-domain-verify=squeak.hackclub.com,0574abe068e7c3c4a91e"
   - "vc-domain-verify=stemegypt.hackclub.com,0c6e30f2705906e4924c"
   - "vc-domain-verify=suceava.hackclub.com,b3c8f92fe1ba1f1f89f4"
   - "vc-domain-verify=teenhack.hackclub.com,83b35a519bc92ba8b94d"


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `TXT vc-domain-verify=squeak.hackclub.com,0574abe068e7c3c4a91e` under `_vercel.hackclub.com`.

Please review carefully before merging.
