### PR TITLE
Delete record for squeak.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5045,9 +5045,6 @@ spud:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
-squeak:
-  type: CNAME
-  value: 9fb4466fee649078.vercel-dns-017.com.
 sshchat:
   type: A
   value: 150.136.142.44


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME 9fb4466fee649078.vercel-dns-017.com.` under `squeak.hackclub.com`.

Please review carefully before merging.
