### PR TITLE
Delete record for archer.hackclub.com.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1444,9 +1444,6 @@ coeur: # olive@hackclub.com @Olive @Ghost of L87 (Lynn)
 coins:
 - type: A
   value: 173.208.140.124
-archer.hackclub.com: # antonio@hackclub.com
-- type: CNAME
-  value: stern.hackclub.com.
 comms:
 - octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME stern.hackclub.com.` under `archer.hackclub.com.hackclub.com`.

Please review carefully before merging.
