### PR TITLE
Add record for finalist.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2106,6 +2106,8 @@ finalist:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
+- type: CNAME
+  value: https://snowy-maple-12.k.hackclub.dev/.
 finder:
   type: CNAME
   value: finder.netlify.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @MaxMph via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
finalist: # maxhurley@hackclub.com U078ZJHUKFW
- type: CNAME
  value: https://snowy-maple-12.k.hackclub.dev/.
```

Added to an existing subdomain entry.

Please review carefully before merging.
