### PR TITLE
Update record for ari.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -585,10 +585,7 @@ backend.arena:
   type: CNAME
   value: fd39bf74a906c3be.vercel-dns-017.com.
 ari: # nathan@hackclub.com
-  octodns:
-    cloudflare:
-      proxied: true
-  type: CNAME
+- type: CNAME
   value: a.selfhosted.hackclub.com.
 webhooks.ari: # nathan@hackclub.com
 - octodns:


### PR DESCRIPTION
## DNS Editor submission

Opened by @sbeltranc via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME a.selfhosted.hackclub.com.` under `ari.hackclub.com`.

### Updated record
```yaml
ari: # nathan@hackclub.com
- type: CNAME
  value: a.selfhosted.hackclub.com.
```

Contact: `nathan@hackclub.com`

Please review carefully before merging.
