### PR TITLE
Add record for snowglobe.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4968,6 +4968,9 @@ snake: # U07EB2Y76DP
 - type: CNAME
   value: yousnakewesnake.netlify.app.
   ttl: 600
+snowglobe: # lola@hackclub.com U078JCFHQ3D
+- type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 soaked: # jenin@hackclub.com // U0926UASBJ7
   octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @lolasanchezz via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
snowglobe: # lola@hackclub.com U078JCFHQ3D
- type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `lola@hackclub.com U078JCFHQ3D`

Please review carefully before merging.
