### PR TITLE
Update record for finalist.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2097,12 +2097,12 @@ fillout-ysws-nps: # zach@hackclub.com
       proxied: true
   type: CNAME
   value: a.limited.selfhosted.hackclub.com.
-finalist:
+finalist: # maxhurley@hackclub.com U078ZJHUKFW
 - octodns:
     cloudflare:
       proxied: true
   type: CNAME
-  value: a.selfhosted.hackclub.com.
+  value: a.ingress.tier2.infra.hackclub.com.
 finder:
   type: CNAME
   value: finder.netlify.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @MaxMph via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME a.selfhosted.hackclub.com.` under `finalist.hackclub.com`.

### Updated record
```yaml
finalist: # maxhurley@hackclub.com U078ZJHUKFW
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `maxhurley@hackclub.com U078ZJHUKFW`

Please review carefully before merging.
