### PR TITLE
MX/SPF/DMARC for hackclub.community (email forwarding)

### DIFF
--- a/hackclub.community.yaml
+++ b/hackclub.community.yaml
@@ -1,4 +1,4 @@
-"":
+"": # alexxxbuilds@gmail.com
 - type: MX
   values:
   - exchange: mx1.improvmx.com.

--- a/hackclub.community.yaml
+++ b/hackclub.community.yaml
@@ -1,4 +1,18 @@
----
+"":
+- type: MX
+  values:
+  - exchange: mx1.improvmx.com.
+    preference: 10
+  - exchange: mx2.improvmx.com.
+    preference: 20
+- type: TXT
+  values:
+  - v=spf1 include:spf.improvmx.com ~all
+
+_dmarc:
+- type: TXT
+  value: v=DMARC1\; p=none\; rua=mailto:alexxxbuilds@gmail.com\;
+
 _vercel:
 - ttl: 300
   type: TXT


### PR DESCRIPTION
Adding MX, SPF, and DMARC records so people can get name@hackclub.community addresses that forward to their own inbox, via ImprovMX (free).

cc @EvanStreams for approval as discussed