### PR TITLE
Update record for haj4ever.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2641,12 +2641,9 @@ hackyeah: # jenny@hackclub.com
 hackyholidays:
   type: CNAME
   value: cname.vercel-dns.com.
-haj4ever: # Rupnil Codes (rupnil.mondal2+hackclub@gmail.com; slack: U0A4UTULSLE) & Flux3tor (tusharsinha199@gmail.com)
-  octodns:
-    cloudflare:
-      proxied: true
-  type: CNAME
-  value: a.ingress.tier2.infra.hackclub.com.
+haj4ever: # U07UK4S94KC
+- type: CNAME
+  value: cname.vercel-dns.com.
 hall-of-fame: # mattsoh@hackclub.com U07DPHQCCCS
 - octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME a.ingress.tier2.infra.hackclub.com.` under `haj4ever.hackclub.com`.

### Updated record
```yaml
haj4ever: # U07UK4S94KC
- type: CNAME
  value: cname.vercel-dns.com.
```

Contact: `U07UK4S94KC`

Please review carefully before merging.
