### PR TITLE
Add record for survive.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5277,6 +5277,12 @@ super-cdn-bot:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
+survive: # dracula@conduct.hackclub.com U0A5PLKMB25
+- octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 swirl: # dhyan@hackclub.com / U0824G9PTFE
   type: CNAME
   value: hackclub.github.io.


### PR DESCRIPTION
## DNS Editor submission

Opened by @0xDracula via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
survive: # dracula@conduct.hackclub.com U0A5PLKMB25
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `dracula@conduct.hackclub.com U0A5PLKMB25`

Please review carefully before merging.
