### PR TITLE
Update record for survive.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5279,7 +5279,10 @@ super-cdn-bot:
   type: CNAME
   value: a.selfhosted.hackclub.com.
 survive: # mihir@hackclub.com U05PRRU5GSJ
-- type: CNAME
+- octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
 swirl: # dhyan@hackclub.com / U0824G9PTFE
   type: CNAME


### PR DESCRIPTION
## DNS Editor submission

Opened by @0xDracula via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME a.ingress.tier2.infra.hackclub.com.` under `survive.hackclub.com`.

### Updated record
```yaml
survive: # mihir@hackclub.com U05PRRU5GSJ
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `mihir@hackclub.com U05PRRU5GSJ`

Please review carefully before merging.
