### PR TITLE
Update record for midnight.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3565,9 +3565,9 @@ midi:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
-midnight:
-  type: A
-  value: 5.161.244.66
+midnight: # echo@hackclub.com
+- type: CNAME
+  value: d96c50e1fa7e0907.vercel-dns-013.com.
 milkyway:
 - octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `A 5.161.244.66` under `midnight.hackclub.com`.

### Updated record
```yaml
midnight: # echo@hackclub.com
- type: CNAME
  value: d96c50e1fa7e0907.vercel-dns-013.com.
```

Contact: `echo@hackclub.com`

Please review carefully before merging.
