### PR TITLE
Update record for pixl.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4122,7 +4122,10 @@ pixeldust:
   type: CNAME
   value: cname.vercel-dns.com.
 pixl: # barnav@hackclub.com U08RVF1BAN4
-- type: CNAME
+- octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
 plausible: # @msw max@hackclub.com
   type: CNAME


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME a.ingress.tier2.infra.hackclub.com.` under `pixl.hackclub.com`.

### Updated record
```yaml
pixl: # barnav@hackclub.com U08RVF1BAN4
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `barnav@hackclub.com U08RVF1BAN4`

Please review carefully before merging.
