### PR TITLE
Update record for hacksteal.hackclub.community

### DIFF
--- a/hackclub.community.yaml
+++ b/hackclub.community.yaml
@@ -59,9 +59,9 @@ emoji: # alimad.co.ltd@gmail.com U08LQFRBL6S
   type: CNAME
   value: emojiout.netlify.app.
 hacksteal: # wangz9096z@gmail.com U08EGTXVCFR
-- type: CNAME
+- ttl: 600
+  type: CNAME
   value: hs.gnahiak2.dev.
-  ttl: 600
 labs: # theawesomeaj.dev@gmail.com U092329JX89
 - ttl: 600
   type: CNAME


### PR DESCRIPTION
## DNS Editor submission

Opened by @gnahiak2 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME hs.gnahiak2.dev.` under `hacksteal.hackclub.community`.

### Updated record
```yaml
hacksteal: # wangz9096z@gmail.com U08EGTXVCFR
- ttl: 600
  type: CNAME
  value: hs.gnahiak2.dev.
```

Contact: `wangz9096z@gmail.com U08EGTXVCFR`

Please review carefully before merging.
