### PR TITLE
Revert "Update hackclub.com.yaml"

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2558,12 +2558,6 @@ hackberry:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
-hackbnb: # leo@hackclub.com U07BLJ1MBEE
-- octodns:
-    cloudflare:
-    proxied: true
-  type: CNAME
-  value: a.ingress.tier2.infra.hackclub.com.
 hackbox:
   type: CNAME
   value: 2d6e6b5e4e98c590.vercel-dns-016.com.


### PR DESCRIPTION
Reverts hackclub/dns#3338

That PR appears to have taken down HCB. A re-run of the deployment GitHub Actions did not fix it, so i'm reverting.

https://github.com/hackclub/dns/actions/runs/31498467868/job/93802026417