### PR TITLE
Add record for cut.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1629,6 +1629,9 @@ ctrlalttec:
 customizer:
 - type: CNAME
   value: jasonappah.github.io.
+cut: # sebh@hackclub.com
+- type: CNAME
+  value: abe48eea6e18ef7c.vercel-dns-013.com.
 d0a9c612-6ccd-4237-829a-e6bcd4e17d4a: # alex@hackclub.com
 - type: TXT
   value: intercom-domain-validation=505c66e9-9ab5-4ca0-9907-4dbe91b6a17c


### PR DESCRIPTION
## DNS Editor submission

Opened by @plastuchino via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
cut: # sebh@hackclub.com
- type: CNAME
  value: abe48eea6e18ef7c.vercel-dns-013.com.
```

Contact: `sebh@hackclub.com`

Please review carefully before merging.
