### PR TITLE
Update record for intercom-files.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3078,12 +3078,9 @@ insertCoin: # gblackburn088@gmail.com
     cloudflare:
       proxied: true
   value: a.selfhosted.hackclub.com.
-intercom-files: #alexd@hackclub.com U02CWS020SD
-- octodns:
-    cloudflare:
-      proxied: false
-  type: CNAME
-  value: hack-club-89976b4c824d.intercom-mail.com.
+intercom-files: # alexd@hackclub.com U02CWS020SD
+- type: CNAME
+  value: hcb-4a1937117a59.intercom-mail.com.
 outbound.intercom: #alexd@hackclub.com U02CWS020SD
 - octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @alexdevz via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME hack-club-89976b4c824d.intercom-mail.com.` under `intercom-files.hackclub.com`.

### Updated record
```yaml
intercom-files: # alexd@hackclub.com U02CWS020SD
- type: CNAME
  value: hcb-4a1937117a59.intercom-mail.com.
```

Contact: `alexd@hackclub.com U02CWS020SD`

Please review carefully before merging.
