### PR TITLE
Add record for prometheus.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4287,6 +4287,12 @@ project: # dhyan@hackclub.com U0824G9PTFE
 prologue: #U0943NG73PA julia@hackclub.com
   type: CNAME
   value: prologue-e4ez8810l.hackclub.dev.
+prometheus: # echo@hackclub.com
+- octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 proton:
   type: CNAME
   value: pxldevv.github.io.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
prometheus: # echo@hackclub.com
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `echo@hackclub.com`

Please review carefully before merging.
