### PR TITLE
Add record for hackxpansion.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2638,6 +2638,12 @@ hackvault: # benjamin.graetz@henleyhs.sa.edu.au U0828CN2BL4
 _github-pages-challenge-BennyGaming635.hackvault: # benjamin.graetz@henleyhs.sa.edu.au U0828CN2BL4
 - type: TXT
   value: eb7c4c7569c1ef4036422ac45273f2
+hackxpansion: # koeglike@proton.me
+- octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 hacky-holidays:
   type: CNAME
   value: cname.vercel-dns.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @KOEGlike via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
hackxpansion: # koeglike@proton.me
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `koeglike@proton.me`

Please review carefully before merging.
