### PR TITLE
Update hackclub.com.yaml

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -782,6 +782,9 @@ az:
 b2b:
 - type: CNAME
   value: nitishsai9.github.io.
+backtothefuture: # adithv08@gmail.com U083XGD4XFY
+- type: CNAME
+  value: atomtables.github.io.
 badge: # leo@hackclub.com U07BLJ1MBEE
 - octodns:
     cloudflare:


### PR DESCRIPTION
# Adding `backtothefuture.hackclub.com`

## Description of changes
- Added an entry `backtothefuture` to `hackclub.com.yaml` that links to `atomtables.github.io`

## Website content/purpose
for Back To The Future ysws

## HQ Sponsor
Dev/Ducc via YSWS online
