### PR TITLE
Update record for sleepy-time.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4994,7 +4994,7 @@ portal.sleepover: #celeste@hackclub.com @thegrammarpolice
   value: a.selfhosted.hackclub.com.
 sleepy-time: # jenny@hackclub.com
 - type: CNAME
-  value: cname.vercel-dns.com.
+  value: 32647ca7673a8216.vercel-dns-017.com.
 slorp: # U07BLJ1MBEE
 - octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @jane-does-coding via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME cname.vercel-dns.com.` under `sleepy-time.hackclub.com`.

### Updated record
```yaml
sleepy-time: # jenny@hackclub.com
- type: CNAME
  value: 32647ca7673a8216.vercel-dns-017.com.
```

Contact: `jenny@hackclub.com`

Please review carefully before merging.
