### PR TITLE
Add record for _vercel.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -335,6 +335,8 @@ _vercel: #
   - "vc-domain-verify=whimsy.hackclub.com,712b4c3c244883005c42"
   - "vc-domain-verify=flickr.hackclub.com,3b44a9f210c4c7d6e72c"
   - "vc-domain-verify=pulsewidth.hackclub.com,b8160f071751810729d5"
+- type: TXT
+  value: "vc-domain-verify=levelzero.hackclub.com,13c7a558faca12814c3c"
 
 _visual-studio-marketplace-hackatime: # U07VC9705D4
   type: TXT


### PR DESCRIPTION
## DNS Editor submission

Opened by @arjav0703 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
_vercel: # arjavjain0703@gmail.com U081ZC7ES30
- type: TXT
  value: "vc-domain-verify=levelzero.hackclub.com,13c7a558faca12814c3c"
```

Added to an existing subdomain entry.

Please review carefully before merging.
