### PR TITLE
Update record for levelzero.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3354,7 +3354,7 @@ leap-manual:
   value: 578b642302902d47.vercel-dns-016.com.
 levelzero: # arjavjain0703@gmail.com U081ZC7ES30
 - type: CNAME
-  value: cname.vercel-dns.com.
+  value: 2e3957c7185a65d0.vercel-dns-013.com.
 lghs:
   type: CNAME
   value: cname.vercel-dns.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME cname.vercel-dns.com.` under `levelzero.hackclub.com`.

### Updated record
```yaml
levelzero: # arjavjain0703@gmail.com U081ZC7ES30
- type: CNAME
  value: 2e3957c7185a65d0.vercel-dns-013.com.
```

Contact: `arjavjain0703@gmail.com U081ZC7ES30`

Please review carefully before merging.
