### PR TITLE
Update record for out-to-c.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3998,8 +3998,11 @@ osiris: # fraud detection :D // hi@skyfall.dev
 - type: CNAME
   value: cname.vercel-dns.com.
 out-to-c: # U098P9DLUGJ
-- type: CNAME
-  value: out-to-c.hackclub.app.
+- octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 outerlan:
 - type: CNAME
   value: hackclub.github.io.


### PR DESCRIPTION
## DNS Editor submission

Opened by @ingobeans via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME out-to-c.hackclub.app.` under `out-to-c.hackclub.com`.

### Updated record
```yaml
out-to-c: # U098P9DLUGJ
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `U098P9DLUGJ`

Please review carefully before merging.
