### PR TITLE
Add record for glassrib.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2398,6 +2398,9 @@ giftbox: # tongyu@hackclub.com U07DJMFAQQP
       proxied: true
   type: CNAME
   value: 4711668836b198ab.vercel-dns-016.com.
+glassrib: # maxhurley@hackclub.com U078ZJHUKFW
+- type: CNAME
+  value: cname.vercel-dns.com.
 glenny:
 - type: CNAME
   value: bobbedbob.github.io.


### PR DESCRIPTION
## DNS Editor submission

Opened by @MaxMph via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
glassrib: # maxhurley@hackclub.com U078ZJHUKFW
- type: CNAME
  value: cname.vercel-dns.com.
```

Contact: `maxhurley@hackclub.com U078ZJHUKFW`

Please review carefully before merging.
