### PR TITLE
Adding `tabbed.hackclub.com`

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5389,6 +5389,9 @@ syscall:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
+tabbed: # U09E9BJ3NKX ary
+  type: CNAME
+  value: 3328b548dde41d98.vercel-dns-013.com.
 tailor: # U08QMC72ZSZT kaylee@hackclub.com
   type: CNAME
   value: 077dcc934b616aac.vercel-dns-016.com.


### PR DESCRIPTION
# Adding `tabbed.hackclub.com`

## Description of changes
Added DNS records for Tabbed YSWS - to be run for my summer online internship.

## Website content/purpose
Tabbed is a YSWS that I'll be running during my online Hackclub summer internship. This website serves as the landing page and shop for my YSWS.

## HQ Sponsor
Deven / Ducc
