### PR TITLE
Adding `glassrib.hackclub.com`

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2398,6 +2398,9 @@ giftbox: # tongyu@hackclub.com U07DJMFAQQP
       proxied: true
   type: CNAME
   value: 4711668836b198ab.vercel-dns-016.com.
+glassrib: # U083W5CCFDG joaquin@hackclub.com
+  type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com
 glenny:
 - type: CNAME
   value: bobbedbob.github.io.


### PR DESCRIPTION
# Adding glassrib.hackclub.com

## Description of changes
Setting up glassrib.hackclub.com to point at my Orchard deployment.
## Website content/purpose
YSWS platform for Glassrib
## HQ Sponsor
guac!