### PR TITLE
Add record for staging.attend.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -740,6 +740,12 @@ attend: # leo@hackclub.com
       proxied: true
   type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
+staging.attend: # leo@hackclub.com
+- octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 aurora:
   type: CNAME
   value: 3dda976f1961c3e4.vercel-dns-016.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @leowilkin via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
staging.attend: # leo@hackclub.com
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `leo@hackclub.com`

Please review carefully before merging.
