### PR TITLE
Add DNS Record: slopdance.hackclub.com using redirectizor repo to

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5180,14 +5180,14 @@ editor.sprig:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
+slopdance: #smelly@gizzy.gay U08D3AY7BG8
+- type: CNAME
+  value: a.selfhosted.hackclub.com.
 spud:
 - octodns:
     cloudflare:
       proxied: true
   type: CNAME
-  value: a.selfhosted.hackclub.com.
-slopdance: #smelly@gizzy.gay U08D3AY7BG8
-- type: CNAME
   value: a.selfhosted.hackclub.com.
 squeak: # echo@hackclub.com
 - type: CNAME

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5186,6 +5186,9 @@ spud:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
+slopdance: #smelly@gizzy.gay U08D3AY7BG8
+- type: CNAME
+  value: a.selfhosted.hackclub.com.
 squeak: # echo@hackclub.com
 - type: CNAME
   value: 46a7cc7d36367365.vercel-dns-013.com.


### PR DESCRIPTION
redirect to stardance.hackclub.com

<!--
This is a template, please modify it to fit your Pull Request. 

Please pick one option when multiple are presented in brackets.

Please title your PR like this: [Adding/Deleting/Updating] `subdomain.[hackclub.com/dino.icu/etc]`
-->

# [Adding/Deleting/Updating] `subdomain.[hackclub.com/dino.icu/etc]`

## Description of changes
<!-- Provide a description of the changes you are making. -->
Add's slopdance.hackclub.com to point to a.selfhosted.hackclub.com as hackclub/redirectorizer says that server to point to

## Website content/purpose
<!-- If you are adding a new subdomain, provide a quick description of the content/purpose of the website you plan to host. -->
Just redirect's slopdance.hackclub.com to stardance.hackclub.com because GOI supervisor Aryan asked since MSW in a GOI zoom a few days ago said he was fine with it and it would be funny!

## HQ Sponsor
<!-- If you are requesting a subdomain under `hackclub.com`, please state the name of your hq POC/sponsor: -->
plastuchino says he supports
<img width="609" height="189" alt="image" src="https://github.com/user-attachments/assets/eb4fbffa-1a78-4e37-bb20-9639f65c402e" />
