### PR TITLE
Add record for slopdance.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5055,6 +5055,12 @@ portal.sleepover: #celeste@hackclub.com @thegrammarpolice
 sleepy-time: # jenny@hackclub.com
 - type: CNAME
   value: 32647ca7673a8216.vercel-dns-017.com.
+slopdance: # smelly@gizzy.gay U08D3AY7BG8
+- octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
+  value: a.selfhosted.hackclub.com.
 slorp: # U07BLJ1MBEE
 - octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @GizzyUwU via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
slopdance: # smelly@gizzy.gay U08D3AY7BG8
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.selfhosted.hackclub.com.
```

Contact: `smelly@gizzy.gay U08D3AY7BG8`

Please review carefully before merging.
