### PR TITLE
Delete record for storybook.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5338,12 +5338,6 @@ storyboard:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
-storybook: # brendan@hackclub.com
-- octodns:
-    cloudflare:
-      proxied: true
-  type: CNAME
-  value: a.ingress.tier2.infra.hackclub.com.
 submit:
 - octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @breynard0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME a.ingress.tier2.infra.hackclub.com.` under `storybook.hackclub.com`.

Please review carefully before merging.
