### PR TITLE
Delete record for beta.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -895,9 +895,6 @@ berkeley:
 berman:
 - type: CNAME
   value: bermanclub.pages.dev.
-beta: # echo@hackclub.com U080A3QP42C
-  type: CNAME
-  value: 6cdac7be6b2e933b.vercel-dns-016.com.
 better-airtable-mcp: # augie@hackclub.com U07FCRNHS1J
 - octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME 6cdac7be6b2e933b.vercel-dns-016.com.` under `beta.hackclub.com`.

Please review carefully before merging.
