### PR TITLE
Add coolify.devansh.dino.icu A record

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -332,10 +332,6 @@ cookie: # cloudglides@proton.me U0A2EKA9FAL
 - ttl: 600
   type: A
   value: 216.198.79.1
-coolify.devansh: # devansh.awat@gmail.com https://github.com/Devansh-awat
-- ttl: 600
-  type: A
-  value: 140.245.203.110
 copilot: # @Yasin U07F2TA4YVB yasin@flonga.org https://yasina74.github.io/copilot-ysws/
 - ttl: 600
   type: CNAME
@@ -386,6 +382,10 @@ dev-email:
   type: TXT
   values:
   - v=spf1 include:spf.improvmx.com ~all
+coolify.devansh: # devansh.awat@gmail.com https://github.com/Devansh-awat
+- ttl: 600
+  type: A
+  value: 140.245.203.110
 hcai.devansh: # devansh.awat@gmail.com https://github.com/Devansh-awat
 - ttl: 600
   type: A
@@ -805,9 +805,9 @@ misskey: #hackisskey | korange753@gmail.com U091Q2MS3T9
   type: TXT
   value: domain-verification=korange # for Nest
 mkv: # drew@drewfitzgerald.co.nz U0AA0EU3G3V
-  - type: CNAME
-    value: mkv.wchouses.co.nz.
-    ttl: 600 # OPTIONAL (defaults to 600)
+- type: CNAME
+  value: mkv.wchouses.co.nz.
+  ttl: 600   # OPTIONAL (defaults to 600)
 molecule: # by https://github.com/RasmusStenlund
   ttl: 600
   type: CNAME
@@ -1057,9 +1057,9 @@ scavenger: # U076W5GKC48
   type: CNAME
   value: nate-greco.github.io.
 schemabuilder: # hackclub-dns@fabian.ternismail.de U0B8JTZDTKQ
-  - ttl: 18000
-    type: A
-    value: 77.90.15.2 # vweb01.eu
+- ttl: 18000
+  type: A
+  value: 77.90.15.2   # vweb01.eu
 sdheeraj: # https://github.com/17sdheeraj/17sdheeraj.github.io
   ttl: 600
   type: CNAME

--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -332,6 +332,10 @@ cookie: # cloudglides@proton.me U0A2EKA9FAL
 - ttl: 600
   type: A
   value: 216.198.79.1
+coolify.devansh: # devansh.awat@gmail.com https://github.com/Devansh-awat
+- ttl: 600
+  type: A
+  value: 140.245.203.110
 copilot: # @Yasin U07F2TA4YVB yasin@flonga.org https://yasina74.github.io/copilot-ysws/
 - ttl: 600
   type: CNAME


### PR DESCRIPTION
Adding an A record for coolify.devansh.dino.icu, pointing at the same server (140.245.203.110) that already hosts hcai.devansh and stardance.devansh. Used to reach a self-hosted Coolify instance.