### PR TITLE
[Adding] `soup3d.dino.icu`

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -1125,6 +1125,10 @@ solvable: # GitHub: Randomcoder323, codingme313@gmail.com
   ttl: 600
   type: CNAME
   value: cname.vercel-dns.com.
+soup3d: # sabhya.aggarwal.18.6@gmail.com U0A9K5RT3HS
+- ttl: 600
+  type: A
+  value: 216.198.79.1
 sparkle: #tlyzachary0411@gmail.com U07DL91MFQT @zook
 - ttl: 600
   type: A

--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -521,6 +521,10 @@ fullhouse: #niko@nikoo.dev U08SF8MVC82
 galaxybrain: # aaranysaini4@gmail.com U0B78MFGH9P
 - type: A
   value: 135.181.209.89
+get: # sabhya.aggarwal@icloud.com U0A83DB0TRN
+- ttl: 600
+  type: A
+  value: 216.198.79.1
 geta: # yoda - https://getadinoicu.yodacode.repl.co/dino.png - get a dino from hackclub/dinosaurs api
   ttl: 600
   type: CNAME


### PR DESCRIPTION
# [Adding] `soup3d.dino.icu`

## Description of changes
Adds a DNS record for `soup3d.dino.icu` in `dino.icu.yaml`.

- Record type: A
- TTL: 600
- Value: 216.198.79.1

## Website content/purpose
Will be a joke/meme website where Souptik Samanta will be selling 3D Prints to Compete with Printing Legion... Just don't tell Nimit

## Contact
- Email: sabhya.aggarwal.18.6@gmail.com
- Slack ID: U0A9K5RT3HS

---
Automated PR from get.dino.icu by @SabhyaAggarwal. Made with love by @SabhyaAggarwal.