### PR TITLE
Add record for unsub.hack.club

### DIFF
--- a/hack.club.yaml
+++ b/hack.club.yaml
@@ -72,3 +72,6 @@ stasis: # alexp@hackclub.com U01581HFAGZ
 summer: # zach@hackclub.com U0266FRGP
   type: CNAME
   value: a.selfhosted.hackclub.com.
+unsub: # U08PUHSMW4V
+- type: CNAME
+  value: e65410cb8a51f4bf.vercel-dns-013.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
unsub: # U08PUHSMW4V
- type: CNAME
  value: e65410cb8a51f4bf.vercel-dns-013.com.
```

Contact: `U08PUHSMW4V`

Please review carefully before merging.
