### PR TITLE
Update record for coeur.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1443,10 +1443,7 @@ codex: # alexren@hackclub.com
   type: CNAME
   value: a.selfhosted.hackclub.com.
 coeur: # olive@hackclub.com @Olive @Ghost of L87 (Lynn)
-  octodns:
-    cloudflare:
-      proxied: true
-  type: CNAME
+- type: CNAME
   value: 24bb8e539241bbef.vercel-dns-016.com.
 coins:
 - type: A


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME 24bb8e539241bbef.vercel-dns-016.com.` under `coeur.hackclub.com`.

### Updated record
```yaml
coeur: # olive@hackclub.com @Olive @Ghost of L87 (Lynn)
- type: CNAME
  value: 24bb8e539241bbef.vercel-dns-016.com.
```

Contact: `olive@hackclub.com @Olive @Ghost of L87 (Lynn)`

Please review carefully before merging.
