### PR TITLE
Update record for tribute.athena.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -722,12 +722,9 @@ express.athena:
 oscillart.athena:
 - type: CNAME
   value: celesteroselli.github.io.
-tribute.athena:
-- octodns:
-    cloudflare:
-      proxied: true
-  type: CNAME
-  value: a.selfhosted.hackclub.com.
+tribute.athena: # U078J6H1XL3
+- type: CNAME
+  value: 52c33a4781d1fce9.vercel-dns-013.com.
 atlantis: # mihir@hackclub.com
 - octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME a.selfhosted.hackclub.com.` under `tribute.athena.hackclub.com`.

### Updated record
```yaml
tribute.athena: # U078J6H1XL3
- type: CNAME
  value: 52c33a4781d1fce9.vercel-dns-013.com.
```

Contact: `U078J6H1XL3`

Please review carefully before merging.
