### PR TITLE
Update record for atlantis.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -729,8 +729,8 @@ atlantis: # mihir@hackclub.com
 - octodns:
     cloudflare:
       proxied: true
-  type: A
-  value: 138.201.55.62
+  type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 attend: # leo@hackclub.com
 - octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @hellonearth311 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `A 138.201.55.62` under `atlantis.hackclub.com`.

### Updated record
```yaml
atlantis: # mihir@hackclub.com
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `mihir@hackclub.com`

Please review carefully before merging.
