### PR TITLE
Update record for vasudev.dino.icu

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -1244,8 +1244,8 @@ vansh:
   type: CNAME
   value: lowkeyvansh.github.io.
 vasudev: # vasudevonden@gmail.com
-- type: CNAME
-  value: Along-the-skies.github.io.
+- type: TXT
+  value: domain-verification=vasudev
 vercel:
 - ttl: 600
   type: CNAME


### PR DESCRIPTION
## DNS Editor submission

Opened by @Along-the-skies via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME Along-the-skies.github.io.` under `vasudev.dino.icu`.

### Updated record
```yaml
vasudev: # vasudevonden@gmail.com
- type: TXT
  value: domain-verification=vasudev
```

Contact: `vasudevonden@gmail.com`

Please review carefully before merging.
