### PR TITLE
Update record for photos.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4198,7 +4198,7 @@ photos: # tom@daamen.uk  U078PH0GBEH
     cloudflare:
       proxied: true
   type: CNAME
-  value: b.selfhosted.hackclub.com.
+  value: cname.vercel-dns.com.
 phs:
 - type: A
   value: 216.150.1.1 # Vercel


### PR DESCRIPTION
## DNS Editor submission

Opened by @deployor via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME b.selfhosted.hackclub.com.` under `photos.hackclub.com`.

### Updated record
```yaml
photos: # tom@daamen.uk  U078PH0GBEH
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: cname.vercel-dns.com.
```

Contact: `tom@daamen.uk  U078PH0GBEH`

Please review carefully before merging.
