### PR TITLE
Update record for ceiling.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1299,10 +1299,7 @@ cecclphs:
 - type: TXT
   value: google-site-verification=_c3oOWsKBUxlmaanXeqC1tBTLNZGflwsEMQQiuP-EUM
 ceiling: # tongyu@hackclub.com U07DJMFAQQP
-- octodns:
-    cloudflare:
-      proxied: true
-  type: CNAME
+- type: CNAME
   value: 32fc8a9e82d43fef.vercel-dns-016.com.
 celestial:
 - type: CNAME


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME 32fc8a9e82d43fef.vercel-dns-016.com.` under `ceiling.hackclub.com`.

### Updated record
```yaml
ceiling: # tongyu@hackclub.com U07DJMFAQQP
- type: CNAME
  value: 32fc8a9e82d43fef.vercel-dns-016.com.
```

Contact: `tongyu@hackclub.com U07DJMFAQQP`

Please review carefully before merging.
