### PR TITLE
Update record for bash.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -847,8 +847,8 @@ barracoders:
 - type: CNAME
   value: barracoders.netlify.app.
 bash: # rushil@hackclub.com U020X4GCWSF
-  type: CNAME
-  value: 1e0993da91f1fd93.vercel-dns-013.com.
+- type: CNAME
+  value: boba-bash-platform.onrender.com.
 resend._domainkey.bash: # rushil@hackclub.com U020X4GCWSF
   type: TXT
   value: "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDkoRoimH6L/m+ibmddlbIXH/3OjrkK3PJEK0aCFSumRF4Otb3WhGJVVCwQOcvl14zthqP0tcUmM6CMmfOYsdvaWE+hnhaxGChNmWdUJqdqu+vYpkxahdVbz0nHe4bMt79XxjGtB/TwYK9BCnc0XOkW1jTQfZrMWINZ/hhGaFrhcwIDAQAB"


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME 1e0993da91f1fd93.vercel-dns-013.com.` under `bash.hackclub.com`.

### Updated record
```yaml
bash: # rushil@hackclub.com U020X4GCWSF
- type: CNAME
  value: boba-bash-platform.onrender.com.
```

Contact: `rushil@hackclub.com U020X4GCWSF`

Please review carefully before merging.
