### PR TITLE
Delete record for bash.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -846,9 +846,6 @@ help.bank:
 barracoders:
 - type: CNAME
   value: barracoders.netlify.app.
-bash: # rushil@hackclub.com U020X4GCWSF
-- type: CNAME
-  value: boba-bash-platform.onrender.com.
 resend._domainkey.bash: # rushil@hackclub.com U020X4GCWSF
   type: TXT
   value: "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDkoRoimH6L/m+ibmddlbIXH/3OjrkK3PJEK0aCFSumRF4Otb3WhGJVVCwQOcvl14zthqP0tcUmM6CMmfOYsdvaWE+hnhaxGChNmWdUJqdqu+vYpkxahdVbz0nHe4bMt79XxjGtB/TwYK9BCnc0XOkW1jTQfZrMWINZ/hhGaFrhcwIDAQAB"


### PR DESCRIPTION
## DNS Editor submission

Opened by @MntRushmore via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME boba-bash-platform.onrender.com.` under `bash.hackclub.com`.

Please review carefully before merging.
