### PR TITLE
Update record for bash.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -847,8 +847,11 @@ barracoders:
 - type: CNAME
   value: barracoders.netlify.app.
 bash: # rushil@hackclub.com U020X4GCWSF
-- type: CNAME
-  value: boba-bash-platform.onrender.com.
+- octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 resend._domainkey.bash: # rushil@hackclub.com U020X4GCWSF
   type: TXT
   value: "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDkoRoimH6L/m+ibmddlbIXH/3OjrkK3PJEK0aCFSumRF4Otb3WhGJVVCwQOcvl14zthqP0tcUmM6CMmfOYsdvaWE+hnhaxGChNmWdUJqdqu+vYpkxahdVbz0nHe4bMt79XxjGtB/TwYK9BCnc0XOkW1jTQfZrMWINZ/hhGaFrhcwIDAQAB"


### PR DESCRIPTION
## DNS Editor submission

Opened by @MntRushmore via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME boba-bash-platform.onrender.com.` under `bash.hackclub.com`.

### Updated record
```yaml
bash: # rushil@hackclub.com U020X4GCWSF
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `rushil@hackclub.com U020X4GCWSF`

Please review carefully before merging.
