### PR TITLE
Update record for vasudev.dino.icu

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -1247,8 +1247,8 @@ vansh:
   type: CNAME
   value: lowkeyvansh.github.io.
 vasudev: # vasudevonden@gmail.com
-- type: TXT
-  value: domain-verification=vasudev
+- type: A
+  value: 135.181.209.89
 vercel:
 - ttl: 600
   type: CNAME


### PR DESCRIPTION
## DNS Editor submission

Opened by @Along-the-skies via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `TXT domain-verification=vasudev` under `vasudev.dino.icu`.

### Updated record
```yaml
vasudev: # vasudevonden@gmail.com
- type: A
  value: 135.181.209.89
```

Contact: `vasudevonden@gmail.com`

Please review carefully before merging.
