### PR TITLE
Update record for twisted.nephthys.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3866,7 +3866,10 @@ summer.nephthys: # amber / U054VC2KM9P
       proxied: true
   value: a.selfhosted.hackclub.com.
 twisted.nephthys: # aoishikkhan@gmail.com U0A5NKH93BJ POC: @plastuchino
-- type: CNAME
+- octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
 nest: # admins@hackclub.app
 - type: CNAME


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME a.ingress.tier2.infra.hackclub.com.` under `twisted.nephthys.hackclub.com`.

### Updated record
```yaml
twisted.nephthys: # aoishikkhan@gmail.com U0A5NKH93BJ POC: @plastuchino
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `aoishikkhan@gmail.com U0A5NKH93BJ POC: @plastuchino`

Please review carefully before merging.
