### PR TITLE
Add record for horus.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3009,6 +3009,12 @@ tickets.horizons: #U056J6JURFF, sofia@hackclub.com
     cloudflare:
       proxied: true
   value: a.selfhosted.hackclub.com.
+horus: # me@lazyllama.xyz - U07F2QA059B
+- octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 '*.hosted':
   type: A
   value: 173.208.140.124


### PR DESCRIPTION
## DNS Editor submission

Opened by @Lazylllama via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
horus: # me@lazyllama.xyz - U07F2QA059B
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `me@lazyllama.xyz - U07F2QA059B`

Please review carefully before merging.
