### PR TITLE
Add record for potluck.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4351,6 +4351,11 @@ potluck: # fiona@hackclub.com
       proxied: true
   type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
+- octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 powertools: # lewin@hackclub.com
 - type: A
   value: 51.148.150.203


### PR DESCRIPTION
## DNS Editor submission

Opened by @rando-muser via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
potluck: # fiona@hackclub.com
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Added to an existing subdomain entry.

Please review carefully before merging.
