### PR TITLE
Update record for throwback.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5611,8 +5611,8 @@ thorn:
 - type: CNAME
   value: thornhack.root.omg.lol.
 throwback: # electricxangell@gmail.com
-- type: CNAME
-  value: cname.vercel-dns.com.
+- type: TXT
+  value: "vc-domain-verify=throwback.hackclub.com,5a7ead2476d82a8b4a48"
 tile:
 - octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @electricxangel via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME cname.vercel-dns.com.` under `throwback.hackclub.com`.

### Updated record
```yaml
throwback: # electricxangell@gmail.com
- type: TXT
  value: "vc-domain-verify=throwback.hackclub.com,5a7ead2476d82a8b4a48"
```

Contact: `electricxangell@gmail.com`

Please review carefully before merging.
