### PR TITLE
Delete record for throwback.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5610,9 +5610,6 @@ thirdspace: # louisa@hackclub.com
 thorn:
 - type: CNAME
   value: thornhack.root.omg.lol.
-throwback: # electricxangell@gmail.com
-- type: TXT
-  value: "vc-domain-verify=throwback.hackclub.com,5a7ead2476d82a8b4a48"
 tile:
 - octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `TXT vc-domain-verify=throwback.hackclub.com,5a7ead2476d82a8b4a48` under `throwback.hackclub.com`.

Please review carefully before merging.
