### PR TITLE
Add record for throwback.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5610,6 +5610,9 @@ thirdspace: # louisa@hackclub.com
 thorn:
 - type: CNAME
   value: thornhack.root.omg.lol.
+throwback: # electricxangell@gmail.com
+- type: CNAME
+  value: 8e177e0b1bd5bf0a.vercel-dns-013.com.
 tile:
 - octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
throwback: # electricxangell@gmail.com
- type: CNAME
  value: 8e177e0b1bd5bf0a.vercel-dns-013.com.
```

Contact: `electricxangell@gmail.com`

Please review carefully before merging.
