### PR TITLE
Add record for metrics.hackatime.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2579,6 +2579,12 @@ db.hackatime: # mahad@hackclub.com
       proxied: true
   type: CNAME
   value: hackatime.limited.selfhosted.hackclub.com.
+metrics.hackatime: # mahad@hackclub.com U059VC0UDEU
+- octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
+  value: hackatime.limited.selfhosted.hackclub.com.
 otel-collector.hackatime: # mahad@hackclub.com
 - octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @skyfallwastaken via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
metrics.hackatime: # mahad@hackclub.com U059VC0UDEU
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: hackatime.limited.selfhosted.hackclub.com.
```

Contact: `mahad@hackclub.com U059VC0UDEU`

Please review carefully before merging.
