### PR TITLE
Add DNS record: zoneout.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -6069,6 +6069,9 @@ zguide:
 zh:
   type: CNAME
   value: a05569dabb46ea5b.vercel-dns-016.com.
+zoneout: # KuzuiYaridomi
+- type: CNAME
+  value: 7f2b72fee5af223c.vercel-dns-013.com.
 zoo:
 - octodns:
     cloudflare:


### PR DESCRIPTION
Adds `zoneout.hackclub.com` → `7f2b72fee5af223c.vercel-dns-013.com.` for the ZoneOut YSWS site, now on the Hack Club Vercel team as project `zoneout` (repo [hackclub/ZoneOut](https://github.com/hackclub/ZoneOut)).