### PR TITLE
Adding `shanghai.dino.icu`

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -1096,6 +1096,10 @@ shammah: # by https://github.com/Gijutsu-T
 - ttl: 600
   type: CNAME
   value: cname.vercel-dns.com.
+shanghai: # manjumusei@gmail.com U0AQMKK8A5U
+- ttl: 600
+  type: A
+  value: 135.181.209.89.
 shipathon: # christian U0938MZG8Q6
 - ttl: 600
   type: A

--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -1099,7 +1099,7 @@ shammah: # by https://github.com/Gijutsu-T
 shanghai: # manjumusei@gmail.com U0AQMKK8A5U
 - ttl: 600
   type: A
-  value: 135.181.209.89.
+  value: 135.181.209.89
 shipathon: # christian U0938MZG8Q6
 - ttl: 600
   type: A


### PR DESCRIPTION
Adds an A record for `shanghai.dino.icu` pointing to 135.181.209.89 (my VPS).
Shanghai Shadows — a browser-based text adventure game set in 1940s occupied Shanghai. Players connect over HTTPS/WebSocket to a game server running on my VPS. Contact: manjumusei@gmail.com / Slack U0AQMKK8A5U.