### PR TITLE
Update record for 555.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -59,7 +59,7 @@
     cloudflare:
       proxied: true
   type: CNAME
-  value: a.ingress.tier2.infra.hackclub.com.
+  value: cname.vercel-dns.com.
 2020-summer: # echo@hackclub.com U080A3QP42C
   type: CNAME
   value: d1a0b01afc6cee8c.vercel-dns-016.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @jamesta361 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME a.ingress.tier2.infra.hackclub.com.` under `555.hackclub.com`.

### Updated record
```yaml
'555': # rudy@hackclub.com
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: cname.vercel-dns.com.
```

Contact: `rudy@hackclub.com`

Please review carefully before merging.
