### PR TITLE
Update record for bento.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -898,7 +898,7 @@ beest: #euan@hackclub.com
   value: b.selfhosted.hackclub.com.
 bento: # freddie@hackclub.com, jared@hackclub.com
 - type: CNAME
-  value: cname.vercel-dns.com.
+  value: 23231db2cd6ee2af.vercel-dns-013.com.
 berkeley:
 - type: CNAME
   value: berkeleyhackclub.github.io.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME cname.vercel-dns.com.` under `bento.hackclub.com`.

### Updated record
```yaml
bento: # freddie@hackclub.com, jared@hackclub.com
- type: CNAME
  value: 23231db2cd6ee2af.vercel-dns-013.com.
```

Contact: `freddie@hackclub.com, jared@hackclub.com`

Please review carefully before merging.
