### PR TITLE
Add record for troeticlicker.dino.icu

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -1242,6 +1242,9 @@ toonnongaeoy:
 - ttl: 600
   type: CNAME
   value: storyhouseproduction.duckdns.org.
+troeticlicker: # admin@henrymeyer.de U0B1CCSCCLF
+- type: A
+  value: 216.198.79.1
 twisted: # for the twisted ysws! (kavyanshkhaitan11@gmail.com, U0A7776A2MT)
 - ttl: 600
   type: A


### PR DESCRIPTION
## DNS Editor submission

Opened by @henrymmey via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
troeticlicker: # admin@henrymeyer.de U0B1CCSCCLF
- type: A
  value: 216.198.79.1
```

Contact: `admin@henrymeyer.de U0B1CCSCCLF`

Please review carefully before merging.
