### PR TITLE
Update record for assets.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -682,9 +682,12 @@ ticketing.assemble:
 ticketing-dev.assemble:
   type: CNAME
   value: f10d2fbccdff8ad4.vercel-dns-016.com.
-assets:
+assets: # echo@hackclub.com
+- octodns:
+    cloudflare:
+      proxied: true
   type: CNAME
-  value: fe3f1381c9138a70.vercel-dns-016.com.
+  value: a.ingress.tier2.infra.hackclub.com.
 _496c10c564509e5030203691afc939ff.assets:
 - octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME fe3f1381c9138a70.vercel-dns-016.com.` under `assets.hackclub.com`.

### Updated record
```yaml
assets: # echo@hackclub.com
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `echo@hackclub.com`

Please review carefully before merging.
