### PR TITLE
Update record for icons.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3081,8 +3081,11 @@ ice:
 - type: CNAME
   value: hackclub.github.io.
 icons: # echo@hackclub.com U080A3QP42C
+- octodns:
+    cloudflare:
+      proxied: true
   type: CNAME
-  value: 82dbb3f826260087.vercel-dns-016.com.
+  value: a.ingress.tier2.infra.hackclub.com.
 id:
   type: CNAME
   value: a05569dabb46ea5b.vercel-dns-016.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME 82dbb3f826260087.vercel-dns-016.com.` under `icons.hackclub.com`.

### Updated record
```yaml
icons: # echo@hackclub.com U080A3QP42C
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `echo@hackclub.com U080A3QP42C`

Please review carefully before merging.
