### PR TITLE
Update record for podium.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4348,9 +4348,9 @@ podcast:
 _github-challenge-Orpheuspod.podcast:
 - type: TXT
   value: b2e369c8f1
-podium: # angad@hackclub.com U075RTSLDQ8
-  type: CNAME
-  value: ingress.lfdl.ink.
+podium: # lola@hackclub.com - U078JCFHQ3D
+- type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 podium-backend: # angad@hackclub.com U075RTSLDQ8
   octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @lolasanchezz via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME ingress.lfdl.ink.` under `podium.hackclub.com`.

### Updated record
```yaml
podium: # lola@hackclub.com - U078JCFHQ3D
- type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `lola@hackclub.com - U078JCFHQ3D`

Please review carefully before merging.
