### PR TITLE
Update record for podium.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4349,7 +4349,10 @@ _github-challenge-Orpheuspod.podcast:
 - type: TXT
   value: b2e369c8f1
 podium: # lola@hackclub.com - U078JCFHQ3D
-- type: CNAME
+- octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
 podium-backend: # angad@hackclub.com U075RTSLDQ8
   octodns:


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME a.ingress.tier2.infra.hackclub.com.` under `podium.hackclub.com`.

### Updated record
```yaml
podium: # lola@hackclub.com - U078JCFHQ3D
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `lola@hackclub.com - U078JCFHQ3D`

Please review carefully before merging.
