### PR TITLE
Add record for hmt-clan.dino.icu

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -628,6 +628,9 @@ dev.hkgi: # HKGI test instance
   ttl: 3600
   type: CNAME
   value: garden.devcara.com.
+hmt-clan: # admin@henrymeyer.de U0B1CCSCCLF
+- type: A
+  value: 216.198.79.1
 hypothesis: # rasmus.stenlund@gmail.com
   ttl: 600
   type: CNAME


### PR DESCRIPTION
## DNS Editor submission

Opened by @henrymmey via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
hmt-clan: # admin@henrymeyer.de U0B1CCSCCLF
- type: A
  value: 216.198.79.1
```

Contact: `admin@henrymeyer.de U0B1CCSCCLF`

Please review carefully before merging.
