### PR TITLE
Add record for chat.ai.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -400,6 +400,12 @@ ai: # mahad@hackclub.com U059VC0UDEU
       proxied: true
   type: CNAME
   value: b.selfhosted.hackclub.com.
+chat.ai: # mahad@hackclub.com U059VC0UDEU
+- octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
+  value: b.selfhosted.hackclub.com.
 docs.ai: # mahad@hackclub.com U059VC0UDEU
 - type: CNAME
   value: 0398d53533e1257d.vercel-dns-016.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @skyfallwastaken via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
chat.ai: # mahad@hackclub.com U059VC0UDEU
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: b.selfhosted.hackclub.com.
```

Contact: `mahad@hackclub.com U059VC0UDEU`

Please review carefully before merging.
