### PR TITLE
Update record for badge.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -813,12 +813,12 @@ backtothefuture: # adithv08@gmail.com U083XGD4XFY
       proxied: true
   type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
-badge: # leo@hackclub.com U07BLJ1MBEE
+badge: # leo@hackclub.com
 - octodns:
     cloudflare:
       proxied: true
   type: CNAME
-  value: a.selfhosted.hackclub.com.
+  value: a.ingress.tier2.infra.hackclub.com.
 bag:
   type: CNAME
   value: c1d487f11a10ad5d.vercel-dns-016.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @leowilkin via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME a.selfhosted.hackclub.com.` under `badge.hackclub.com`.

### Updated record
```yaml
badge: # leo@hackclub.com
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `leo@hackclub.com`

Please review carefully before merging.
