### PR TITLE
Update record for visas.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -6058,12 +6058,12 @@ _gh-HackClub-Vidisha-o.vidisha:
 vikingsdev:
 - type: CNAME
   value: vikingsdev.github.io.
-visas: # leo@hackclub.com U07BLJ1MBEE
+visas: # leo@hackclub.com
 - octodns:
     cloudflare:
       proxied: true
   type: CNAME
-  value: a.selfhosted.hackclub.com.
+  value: a.ingress.tier2.infra.hackclub.com.
 vision:
 - octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @leowilkin via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME a.selfhosted.hackclub.com.` under `visas.hackclub.com`.

### Updated record
```yaml
visas: # leo@hackclub.com
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `leo@hackclub.com`

Please review carefully before merging.
