### PR TITLE
Update record for submit.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5577,12 +5577,12 @@ storyboard:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
-submit:
+submit: # leo@hackclub.com
 - octodns:
     cloudflare:
       proxied: true
   type: CNAME
-  value: a.selfhosted.hackclub.com.
+  value: a.ingress.tier2.infra.hackclub.com.
 docs.submit:
 - octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @leowilkin via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME a.selfhosted.hackclub.com.` under `submit.hackclub.com`.

### Updated record
```yaml
submit: # leo@hackclub.com
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `leo@hackclub.com`

Please review carefully before merging.
