### PR TITLE
Update record for data.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1696,12 +1696,12 @@ dashboard:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
-data: # U07BLJ1MBEE leo
+data: # leo@hackclub.com
 - octodns:
     cloudflare:
       proxied: true
   type: CNAME
-  value: a.selfhosted.hackclub.com.
+  value: a.ingress.tier2.infra.hackclub.com.
 daydream:
 - octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @leowilkin via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME a.selfhosted.hackclub.com.` under `data.hackclub.com`.

### Updated record
```yaml
data: # leo@hackclub.com
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `leo@hackclub.com`

Please review carefully before merging.
