### PR TITLE
Update record for hackcraft.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2686,9 +2686,12 @@ hackbnb: # leo@hackclub.com U07BLJ1MBEE
 hackbox:
   type: CNAME
   value: 2d6e6b5e4e98c590.vercel-dns-016.com.
-hackcraft:
+hackcraft: # echo@hackclub.com
+- octodns:
+    cloudflare:
+      proxied: true
   type: CNAME
-  value: 77d1240fc50c2ff8.vercel-dns-016.com.
+  value: a.ingress.tier2.infra.hackclub.com.
 botfights.hackcraft: # christian on slack U0938MZG8Q6 event under felix
   type: CNAME
   value: 8726bb0e95fb84f0.vercel-dns-017.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME 77d1240fc50c2ff8.vercel-dns-016.com.` under `hackcraft.hackclub.com`.

### Updated record
```yaml
hackcraft: # echo@hackclub.com
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `echo@hackclub.com`

Please review carefully before merging.
