### PR TITLE
Delete record for kintsugi.nephthys.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3955,12 +3955,6 @@ jumpstart.nephthys: # mish@hackclub.com U073M5L9U13
     cloudflare:
       proxied: true
   value: b.selfhosted.hackclub.com.
-kintsugi.nephthys: # aoishikkhan@gmail.com U0A5NKH93BJ POC: @plastuchino
-- octodns:
-    cloudflare:
-      proxied: true
-  type: CNAME
-  value: a.ingress.tier2.infra.hackclub.com.
 lynx.nephthys: # Nathan U05EZRFKRV4 & Santi U08PD2ZB3DL
   type: CNAME
   octodns:


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME a.ingress.tier2.infra.hackclub.com.` under `kintsugi.nephthys.hackclub.com`.

Please review carefully before merging.
