### PR TITLE
Add record for coral.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1590,6 +1590,12 @@ coolify-conductor:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
+coral: # aarav@hackclub.com U07UK4S94KC
+- octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 cornelius: #CAN
 - octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @aaravjhamb via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
coral: # aarav@hackclub.com U07UK4S94KC
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `aarav@hackclub.com U07UK4S94KC`

Please review carefully before merging.
