### PR TITLE
Add record for cdn.coral.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1596,6 +1596,12 @@ coral: # aarav@hackclub.com U07UK4S94KC
       proxied: true
   type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
+cdn.coral: # aarav@hackclub.com U07UK4S94KC
+- octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 cornelius: #CAN
 - octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @aaravjhamb via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
cdn.coral: # aarav@hackclub.com U07UK4S94KC
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `aarav@hackclub.com U07UK4S94KC`

Please review carefully before merging.
