### PR TITLE
Add CNAME records for unified.help and uhsbot.help

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3024,6 +3024,9 @@ helm:
 unified.help: # ormie@normiecodes.dev U098F6EJ34J
 - type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
+uhsbot.help:
+- type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 help: # U096RMRG03G -- for #help channel in slack
   type: CNAME
   value: 262fbe4a85815191.vercel-dns-016.com.

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3021,10 +3021,10 @@ heist-api:
 helm:
 - type: CNAME
   value: helm-bgh.pages.dev.
-unified.help: # ormie@normiecodes.dev U098F6EJ34J
+unified.help: # normie@normiecodes.dev U098F6EJ34J
 - type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
-uhsbot.help:
+uhsbot.help: # normie@normiecodes.dev U098F6EJ34J
 - type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
 help: # U096RMRG03G -- for #help channel in slack

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3021,15 +3021,15 @@ heist-api:
 helm:
 - type: CNAME
   value: helm-bgh.pages.dev.
-unified.help: # normie@normiecodes.dev U098F6EJ34J
-- type: CNAME
-  value: a.ingress.tier2.infra.hackclub.com.
-uhsbot.help: # normie@normiecodes.dev U098F6EJ34J
-- type: CNAME
-  value: a.ingress.tier2.infra.hackclub.com.
 help: # U096RMRG03G -- for #help channel in slack
   type: CNAME
   value: 262fbe4a85815191.vercel-dns-016.com.
+uhsbot.help: # normie@normiecodes.dev U098F6EJ34J
+- type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
+unified.help: # normie@normiecodes.dev U098F6EJ34J
+- type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 helvetica: # maxhurley@hackclub.com or U078ZJHUKFW
 - type: CNAME
   value: e4344067818d06d7.vercel-dns-016.com.

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3021,6 +3021,9 @@ heist-api:
 helm:
 - type: CNAME
   value: helm-bgh.pages.dev.
+unified.help: # ormie@normiecodes.dev U098F6EJ34J
+- type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 help: # U096RMRG03G -- for #help channel in slack
   type: CNAME
   value: 262fbe4a85815191.vercel-dns-016.com.


### PR DESCRIPTION
# Adding `unified.help.hackclub.com` and `uhsbot.help.hackclub.com`

## Description of changes
Adds the Unified Help website and Unified Help scraper bot to the Hack Club DNS under the help.hackclub.com domain.

## Website content/purpose
Unified Help allows Hack Club support helpers to view and handle Hack Club support tickets in one place, allowing you to filter and sort tickets faster and more efficiently. It allows helpers to filter and sort tickets by status (open, assigned and resolved), assignment, etc., view tickets across programs in Unified Help, reply to tickets directly within Unified Help, resolve and reopen tickets, and see statistics like median resolve time, hang time, ticket replies per hour and per weekday, for each program and each profile across all programs, and more. 

Unified Help is used by 14/19 helpers in the #help channel and it has been approved for use for the Help channel helpers (#help) on Slack under Evan Streams. 

See where it is currently hosted: https://unifiedhelp.normiecodes.dev, the #ship post: https://hackclub.slack.com/archives/C0M8PUPU6/p1785461943939989, and the GitHub repository: https://github.com/normalperson543/unified-help

The uhsbot.help.hackclub.com domain allows the Unified Help Scraper bot (https://github.com/normalperson543/unified-help-scraper) to receive Slack events for indexing new help tickets on Slack over HTTP.

Unified Help and the scraper bot are both hosted on Orchard.

## HQ Sponsor
Evan Streams
