### PR TITLE
Add record for booking.haven.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2844,6 +2844,12 @@ haven:  # haven@hackclub.com
     lenient: true
   type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
+booking.haven: # haven@hackclub.com
+- octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 haxidraw:
   type: CNAME
   value: cname.vercel-dns.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @jollyroger182 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
booking.haven: # haven@hackclub.com
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `haven@hackclub.com`

Please review carefully before merging.
