### PR TITLE
Update record for capitol.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1256,12 +1256,12 @@ training.campfire: # U022XFD2TML
 tutorial.campfire: # deven@hackclub.com
 - type: CNAME
   value: 23f9766d334e905c.vercel-dns-016.com.
-capitol: # maxhurley@hackclub.com U078ZJHUKFW
+capitol: # antonio@hackclub.com
 - octodns:
     cloudflare:
       proxied: true
   type: CNAME
-  value: a.ingress.tier2.infra.hackclub.com.
+  value: 2a231110952d8730.vercel-dns-013.com.
 capsule:
 - type: CNAME
   value: cname.vercel-dns.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @AD-Archer via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME a.ingress.tier2.infra.hackclub.com.` under `capitol.hackclub.com`.

### Updated record
```yaml
capitol: # antonio@hackclub.com
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: 2a231110952d8730.vercel-dns-013.com.
```

Contact: `antonio@hackclub.com`

Please review carefully before merging.
