### PR TITLE
Update record for cq.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1634,8 +1634,11 @@ coxmill:
 - type: CNAME
   value: modest-swanson-0a9aa6.netlify.app.
 cq: # ruben@scstudios.tech U0AHNB20WDD
-- type: CNAME
-  value: d6ef4380bc58fb9f.vercel-dns-013.com.
+- octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 craft:
 - type: CNAME
   value: craft-ept.pages.dev.


### PR DESCRIPTION
## DNS Editor submission

Opened by @code2344 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME d6ef4380bc58fb9f.vercel-dns-013.com.` under `cq.hackclub.com`.

### Updated record
```yaml
cq: # ruben@scstudios.tech U0AHNB20WDD
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `ruben@scstudios.tech U0AHNB20WDD`

Please review carefully before merging.
