### PR TITLE
Add cybersparks.hackclub.com for FTC team CyberSparks

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1699,6 +1699,9 @@ customizer:
 cut: # sebh@hackclub.com
 - type: CNAME
   value: abe48eea6e18ef7c.vercel-dns-013.com.
+cybersparks: # FTC team CyberSparks
+- type: CNAME
+  value: cname.vercel-dns.com.
 d0a9c612-6ccd-4237-829a-e6bcd4e17d4a: # alex@hackclub.com
 - type: TXT
   value: intercom-domain-validation=505c66e9-9ab5-4ca0-9907-4dbe91b6a17c

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -262,6 +262,7 @@ _vercel: #
   - "vc-domain-verify=celestial.hackclub.com,712c9345didfd5e0b4ee"
   - "vc-domain-verify=codecafe.hackclub.com,7626bb39bfb56e9ea791"
   - "vc-domain-verify=contact-helper.hackclub.com,ecd049f45e2ad550fd89"
+  - "vc-domain-verify=cybersparks.hackclub.com,3bd1ea42f30e30427cac"
   - "vc-domain-verify=descend.hackclub.com,766f399a5ac7216e01a1"
   - "vc-domain-verify=dessert.hackclub.com,8452d8879c3995b17783"
   - "vc-domain-verify=docs.identity.hackclub.com,ef5c12615db913aa8dee"

--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1700,7 +1700,7 @@ customizer:
 cut: # sebh@hackclub.com
 - type: CNAME
   value: abe48eea6e18ef7c.vercel-dns-013.com.
-cybersparks: # FTC team CyberSparks
+cybersparks: # cybersparks7@gmail.com
 - type: CNAME
   value: cname.vercel-dns.com.
 d0a9c612-6ccd-4237-829a-e6bcd4e17d4a: # alex@hackclub.com


### PR DESCRIPTION

Adding cybersparks.hackclub.com

Description of changes
Adds a CNAME entry for cybersparks.hackclub.com pointing to cname.vercel-dns.com., plus a vc-domain-verify TXT record under _vercel.hackclub.com for Vercel domain verification.

Website content/purpose
Website for FTC robotics team CyberSparks (hosted on Vercel — https://cybersparks.vercel.app/). Team info, outreach, sponsors, and season updates.

HQ Sponsor
Lucy Tran (HCB point of contact for our FTC team)