### PR TITLE
Delete record for maps.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3699,9 +3699,6 @@ manifesto:
 manor:
   type: CNAME
   value: f61dcda8ea43ee0c.vercel-dns-016.com.
-maps:
-  type: CNAME
-  value: f5e7996f6a74bcc1.vercel-dns-016.com.
 markdown:
   type: CNAME
   value: c02a5eb37aa5d3c3.vercel-dns-016.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME f5e7996f6a74bcc1.vercel-dns-016.com.` under `maps.hackclub.com`.

Please review carefully before merging.
