### PR TITLE
Delete record for opensauce2026.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4183,9 +4183,6 @@ opensauce: # zach@hackclub.com
       proxied: false
   type: CNAME
   value: a.limited.selfhosted.hackclub.com.
-opensauce2026: # alexren@hackclub.com
-  type: CNAME
-  value: 68b1465d7a634413.vercel-dns-016.com.
 opensauce-leaderboard: # zach@hackclub.com
 - octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME 68b1465d7a634413.vercel-dns-016.com.` under `opensauce2026.hackclub.com`.

Please review carefully before merging.
