### PR TITLE
Delete record for suceava.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5634,9 +5634,6 @@ staging.submit:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
-suceava:
-  type: CNAME
-  value: cname.vercel-dns.com.
 summer:
 - octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME cname.vercel-dns.com.` under `suceava.hackclub.com`.

Please review carefully before merging.
