### PR TITLE
Delete record for sleepy-time.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5309,9 +5309,6 @@ portal.sleepover: #celeste@hackclub.com @thegrammarpolice
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
-sleepy-time: # jenny@hackclub.com
-- type: CNAME
-  value: 32647ca7673a8216.vercel-dns-017.com.
 slopdance: # smelly@gizzy.gay U08D3AY7BG8
 - octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME 32647ca7673a8216.vercel-dns-017.com.` under `sleepy-time.hackclub.com`.

Please review carefully before merging.
