### PR TITLE
Delete record for globalcovid.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2516,9 +2516,6 @@ glassrib: # U083W5CCFDG joaquin@hackclub.com
 glenny:
 - type: CNAME
   value: bobbedbob.github.io.
-globalcovid:
-  type: CNAME
-  value: globalcovid.netlify.com.
 golden:
   type: CNAME
   value: 57cd2901f886bca3.vercel-dns-016.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME globalcovid.netlify.com.` under `globalcovid.hackclub.com`.

Please review carefully before merging.
