### PR TITLE
Delete record for renaissance-24.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4752,9 +4752,6 @@ remixed: # ascpixi@hackclub.com U082DPCGPST
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
-renaissance-24:
-  type: CNAME
-  value: 1bdc13681dff9b21.vercel-dns-016.com.
 resolution: # dhamari@hackclub.com // jenin@hackclub.com
 - type: A
   value: 216.150.1.1 # Vercel


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME 1bdc13681dff9b21.vercel-dns-016.com.` under `renaissance-24.hackclub.com`.

Please review carefully before merging.
