### PR TITLE
Delete record for angelhacks-toronto.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -509,9 +509,6 @@ anchor:
 angelhacks:
 - type: CNAME
   value: 18cadf91c1eccd94.vercel-dns-016.com.
-angelhacks-toronto:
-  type: CNAME
-  value: cname.vercel-dns.com.
 angelhacks-yyz:
 - type: CNAME
   value: ffa02a6c0ac70a16.vercel-dns-016.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME cname.vercel-dns.com.` under `angelhacks-toronto.hackclub.com`.

Please review carefully before merging.
