### PR TITLE
Delete record for asylum.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -710,9 +710,6 @@ asw:
   value: 67.217.241.159
 - type: TXT
   value: google-site-verification=d_K6jzYREeilfewHLzAj968pU2v_z1ZBY1aNrXSt_Pg
-asylum:
-  type: CNAME
-  value: cname.vercel-dns.com.
 athena: # reem@hackclub.com
 - octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME cname.vercel-dns.com.` under `asylum.hackclub.com`.

Please review carefully before merging.
