### PR TITLE
Delete record for az.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -797,9 +797,6 @@ awest:
 axiom: # tanjimkamal1@gmail.com U09ASUK57K8
   type: CNAME
   value: 8bfbc5e47c699b10.vercel-dns-016.com.
-az:
-  type: CNAME
-  value: a05569dabb46ea5b.vercel-dns-016.com.
 b2b:
 - type: CNAME
   value: nitishsai9.github.io.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME a05569dabb46ea5b.vercel-dns-016.com.` under `az.hackclub.com`.

Please review carefully before merging.
