### PR TITLE
Delete record for ia.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3153,9 +3153,6 @@ hsi:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
-ia:
-  type: CNAME
-  value: cname.vercel-dns.com.
 iaw:
   type: CNAME
   value: iawhackclub.netlify.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME cname.vercel-dns.com.` under `ia.hackclub.com`.

Please review carefully before merging.
