### PR TITLE
Delete record for vault.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -6057,9 +6057,6 @@ valveprospectusbrendan: # brendan@hackclub.com
       proxied: true
   type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
-vault:
-- type: CNAME
-  value: cname.vercel-dns.com.
 veil:
 - octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME cname.vercel-dns.com.` under `vault.hackclub.com`.

Please review carefully before merging.
