### PR TITLE
Delete record for pomperaug.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4476,9 +4476,6 @@ polygon: # zaidayan456@gmail.com U083VVA9M0W
   ttl: 600
   type: CNAME
   value: 1f2e326ff0beb553.vercel-dns-017.vercel-dns.com.
-pomperaug:
-  type: CNAME
-  value: cname.vercel-dns.com.
 portal:
 - type: CNAME
   value: ingress.lfdl.ink.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME cname.vercel-dns.com.` under `pomperaug.hackclub.com`.

Please review carefully before merging.
