### PR TITLE
Delete record for raincloud.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4680,9 +4680,6 @@ railway:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
-raincloud:
-- type: CNAME
-  value: cname.vercel-dns.com.
 ranked: # meghana@hackclub.com
 - type: CNAME
   value: a6d766a2716a5ed3.vercel-dns-013.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME cname.vercel-dns.com.` under `raincloud.hackclub.com`.

Please review carefully before merging.
