### PR TITLE
Delete record for turner.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5960,9 +5960,6 @@ turfwars: # mihir@hackclub.com
     cloudflare:
       proxied: true
   value: a.ingress.tier2.infra.hackclub.com.
-turner:
-- type: CNAME
-  value: cname.vercel-dns.com.
 turnover:
 - type: CNAME
   value: 22f4f50b2688160c.vercel-dns-016.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME cname.vercel-dns.com.` under `turner.hackclub.com`.

Please review carefully before merging.
