### PR TITLE
Delete record for laslomas.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3518,9 +3518,6 @@ largo: # largo.hackclub.com
 lasa:
   type: CNAME
   value: hackclublasa.github.io.
-laslomas:
-  type: CNAME
-  value: mystifying-torvalds-f8e697.netlify.com.
 leaderboard:
   type: CNAME
   value: d504d7ff43570fc2.vercel-dns-016.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME mystifying-torvalds-f8e697.netlify.com.` under `laslomas.hackclub.com`.

Please review carefully before merging.
