### PR TITLE
Deleting `hackclub.com` CNAME records

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -253,11 +253,9 @@ _vercel: #
   - "vc-domain-verify=backend.arena.hackclub.com,079b94be7b001fa4e775"
   - "vc-domain-verify=birthday.hackclub.com,b54f1e09bf276faffd29"
   - "vc-domain-verify=birthdays.hackclub.com,7ca55aea82d546d470e1"
-  - "vc-domain-verify=blair.hackclub.com,7de7c7631e837097d2a2"
   - "vc-domain-verify=boot.hackclub.com,d42729095e2b6b414e75"
   - "vc-domain-verify=botfights.hackcraft.hackclub.com,0a512bcbd28db8e3d5bc"
   - "vc-domain-verify=branch.hackclub.com,21874c5af09f455c2cc0"
-  - "vc-domain-verify=bunker.apocalypse.hackclub.com,75a61be6a0e63f44d7c1"
   - "vc-domain-verify=capsule.hackclub.com,2095a0d425ab70e65ae2"
   - "vc-domain-verify=celestial.hackclub.com,712c9345didfd5e0b4ee"
   - "vc-domain-verify=codecafe.hackclub.com,7626bb39bfb56e9ea791"
@@ -541,9 +539,6 @@ api2:
 apocalypse:
 - type: CNAME
   value: aa060dd312321f2d.vercel-dns-016.com.
-bunker.apocalypse:
-- type: CNAME
-  value: cname.vercel-dns.com.
 app:
 - octodns:
     cloudflare:
@@ -680,9 +675,6 @@ preflight.assemble:
 register.assemble:
   type: CNAME
   value: 49ac53df65c15b11.vercel-dns-016.com.
-scrapbook.assemble:
-- type: CNAME
-  value: 898a81e2c5eed0c1.vercel-dns-016.com.
 ticketing.assemble:
   type: CNAME
   value: f10d2fbccdff8ad4.vercel-dns-016.com.
@@ -854,9 +846,6 @@ changelog.bank:
 help.bank:
   type: CNAME
   value: hcb-proxy.servers.hackclub.com.
-barracoders:
-- type: CNAME
-  value: barracoders.netlify.app.
 bash: # rushil@hackclub.com U020X4GCWSF
 - octodns:
     cloudflare:
@@ -903,9 +892,6 @@ beest: #euan@hackclub.com
 bento: # freddie@hackclub.com, jared@hackclub.com
 - type: CNAME
   value: 23231db2cd6ee2af.vercel-dns-013.com.
-berkeley:
-- type: CNAME
-  value: berkeleyhackclub.github.io.
 berman:
 - type: CNAME
   value: bermanclub.pages.dev.
@@ -963,9 +949,6 @@ blackbox:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
-blair:
-  type: CNAME
-  value: cname.vercel-dns.com.
 blare: #U08EUSU38VC liam@hackclub.com
 - type: CNAME
   value: 0ccb2c845a82c668.vercel-dns-016.com.
@@ -1045,9 +1028,6 @@ braize: # jenny@hackclub.com
 branch:
 - type: CNAME
   value: 7f6ac627cb1e65e3.vercel-dns-017.com.
-brasil:
-  type: CNAME
-  value: hack-club-brasil.netlify.app.
 breadboard: # tanishq@hackclub.comU08R4Q9H8EB
   type: CNAME
   octodns:
@@ -1069,9 +1049,6 @@ www.bridgeportohio:
 browserbuddy:
 - type: CNAME
   value: 6ba8f4ef62be7911.vercel-dns-016.com.
-bubble: # jared@hackclub.com U07HEH4N8UV 
-- type: CNAME
-  value: bc88611c121f3104.vercel-dns-016.com.
 bucky:
 - octodns:
     cloudflare:
@@ -1327,9 +1304,6 @@ cecclphs:
 ceiling: # tongyu@hackclub.com U07DJMFAQQP
 - type: CNAME
   value: 32fc8a9e82d43fef.vercel-dns-016.com.
-celestial:
-- type: CNAME
-  value: cname.vercel-dns.com.
 cgc:
 - type: CNAME
   value: hackclubcgc.netlify.app.
@@ -1394,9 +1368,6 @@ clam: # mihir@hackclub.com U0BC86VAYT0
 bag.client:
   type: A
   value: 34.49.72.119
-cloud: # antonio@hackclub.com
-- type: CNAME
-  value: cname.vercel-dns.com.
 cloudfall: # antonio@hackclub.com
 - type: CNAME
   value: cname.vercel-dns.com.
@@ -1764,9 +1735,6 @@ defector: # lewin@hackclub.com
   value: 51.148.150.203
 - type: AAAA
   value: 2a02:8012:477e:1::e
-descend:
-- type: CNAME
-  value: cname.vercel-dns.com.
 dessert:
 - type: CNAME
   value: cname.vercel-dns.com.
@@ -1892,10 +1860,7 @@ dummies:
     cloudflare:
       proxied: true
   type: CNAME
-  value: a.selfhosted.hackclub.com.
-dv:
-  type: CNAME
-  value: cname.vercel-dns.com.
+  value: a.selfhosted.hackclub.com.editor
 easel:
   type: CNAME
   value: 46c19d5618208b3e.vercel-dns-016.com.
@@ -2139,12 +2104,6 @@ extensify:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
-fab:
-- type: CNAME
-  value: cname.vercel-dns.com.
-editor.fab:
-  type: CNAME
-  value: cname.vercel-dns.com.
 failover: # echo@hackclub.com
 - octodns:
     cloudflare:
@@ -2600,9 +2559,6 @@ hackarest:
 hackaruto:
 - type: CNAME
   value: hackaruto.netlify.app.
-hackathon:
-- type: CNAME
-  value: cname.vercel-dns.com.
 hackathons:
 - type: CNAME
   value: 4f4247fba98f6cdd.vercel-dns-016.com.
@@ -2672,9 +2628,6 @@ hackatsst:
 hackaway:
 - type: CNAME
   value: starlit-cascaron-ab17de.netlify.app.
-hackbeats:
-  type: CNAME
-  value: csb-yzetpt.vercel.app.
 hackberry:
   octodns:
     cloudflare:
@@ -2745,14 +2698,7 @@ hacksaber:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
-hackstore:
-  type: CNAME
-  value: cname.vercel-dns.com.
 hacktheoctober:
-  type: CNAME
-  value: cname.vercel-dns.com.
-hacktks:
-- ttl: 1
   type: CNAME
   value: cname.vercel-dns.com.
 hackvault: # benjamin.graetz@henleyhs.sa.edu.au U0828CN2BL4
@@ -2842,21 +2788,9 @@ booking.haven: # haven@hackclub.com
       proxied: true
   type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
-haxidraw:
-  type: CNAME
-  value: cname.vercel-dns.com.
-editor.haxidraw:
-  type: CNAME
-  value: cname.vercel-dns.com.
 haxmas: # echo@hackclub.com
 - type: CNAME
   value: cname.vercel-dns.com.
-hc-repo:
-  octodns:
-    cloudflare:
-      proxied: true
-  type: CNAME
-  value: a.selfhosted.hackclub.com.
 hcarc:
 - type: MX
   values:
@@ -3034,9 +2968,6 @@ helvetica: # maxhurley@hackclub.com or U078ZJHUKFW
 hermes:
   type: CNAME
   value: meghanam4.github.io.
-hersey:
-- type: CNAME
-  value: cname.vercel-dns.com.
 high-seas:
 - type: CNAME
   value: 992022aa5b4ad559.vercel-dns-016.com.
@@ -3158,9 +3089,6 @@ icons: # echo@hackclub.com U080A3QP42C
       proxied: true
   type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
-id:
-  type: CNAME
-  value: a05569dabb46ea5b.vercel-dns-016.com.
 identity:
 - octodns:
     cloudflare:
@@ -3449,9 +3377,6 @@ v1.jumpstart: # estella@hackclub.com U06UYA4AH6F
 v2.jumpstart: #estella@hackclub.com U06UYA4AH6F
 - type: CNAME
   value: themagicfrog.github.io.
-jv:
-- type: CNAME
-  value: awesome-carson-c7b5e3.netlify.com.
 keeb: #U05JNJZJ0BS
 - type: CNAME
   octodns:
@@ -3476,12 +3401,6 @@ kjcmt:
 kmea:
   type: A
   value: 185.199.111.153
-knit:
-  type: CNAME
-  value: hackclubknit.netlify.app.
-ko:
-  type: CNAME
-  value: cname.vercel-dns.com.
 lambert:
   type: CNAME
   value: lambert-hackclub.vercel.app.
@@ -3691,12 +3610,6 @@ market:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
-mason:
-  type: CNAME
-  value: mason-hack-club.netlify.com.
-matchups:
-  type: CNAME
-  value: cname.vercel-dns.com.
 maxday:
   type: CNAME
   value: maxday-prod.netlify.com.
@@ -4013,12 +3926,6 @@ nest: # admins@hackclub.app
 nestm:
   type: CNAME
   value: 898dacf1cb90052f.vercel-dns-016.com.
-newcanaan:
-  type: CNAME
-  value: cname.vercel-dns.com.
-newcanaanlib:
-  type: CNAME
-  value: cname.vercel-dns.com.
 news: # eps@hackclub.com U09Q8MLTE58 & hc+dns@matmanna.dev U07VA44DNBA;
 - type: A
   value: 216.150.1.1
@@ -4193,9 +4100,6 @@ orpheus-engine:
 orpheushacks: # Harrison Katz automatically wins for adding the DNS entry - thats how it works, right?
 - type: CNAME
   value: 2f89c690cf78cd8b.vercel-dns-016.com.
-orpheusodyssey:
-- type: CNAME
-  value: 1b3djzn4.up.railway.app.
 orpheuspico:
 - type: CNAME
   value: 9dbd6e68981e4fde.vercel-dns-016.com.
@@ -4205,9 +4109,6 @@ osca:
 _github-pages-challenge-OSCA-Hack-Club.osca:
 - type: TXT
   value: 05f02f6fc6cce92877573361810958
-osiris: # fraud detection :D // hi@skyfall.dev
-- type: CNAME
-  value: cname.vercel-dns.com.
 out-to-c: # U098P9DLUGJ
 - octodns:
     cloudflare:
@@ -4329,12 +4230,6 @@ penumbra: # ascpixi@hackclub.com U082DPCGPST
 pfp:
 - type: A
   value: 77.90.16.198
-philanthropy:
-  type: CNAME
-  value: cname.vercel-dns.com.
-philippines:
-- type: CNAME
-  value: cname.vercel-dns.com.
 photos: # tom@daamen.uk U078PH0GBEH
 - type: CNAME
   value: 6b1e660c03c871f3.vercel-dns-013.com.
@@ -4456,9 +4351,6 @@ mathesar.podium-backend: # angad@hackclub.com U075RTSLDQ8
       proxied: true
   type: CNAME
   value: b.selfhosted.hackclub.com.
-polaris: #adishree@horizons.hackclub.com U07DEBE2RUL
-- type: CNAME
-  value: horizonspolaris.netlify.app.
 polaroid:
   type: CNAME
   value: polaroid.iunstable0.com.
@@ -4809,9 +4701,6 @@ rework: # mgoldbergspar@gmail.com U08TCSANHDX
 riceathon:
   type: CNAME
   value: 1fe8ce5ecab1c74e.vercel-dns-016.com.
-riverbend:
-  type: CNAME
-  value: yousefhaggy.github.io.
 riverside:
   type: CNAME
   value: aahannadas.github.io.
@@ -5217,12 +5106,6 @@ sinerider-scoring:
 singgasana:
   type: CNAME
   value: singgasana.netlify.app.
-six7: # meghana@hackclub.com U06P62WGWAV
-  type: CNAME
-  value: 011deaf9e530ac38.vercel-dns-013.com.
-sixseven: # meghana@hackclub.com U06P62WGWAV
-  type: CNAME
-  value: 011deaf9e530ac38.vercel-dns-013.com.
 sji:
   type: CNAME
   value: sji-hack-club.github.io.
@@ -5322,10 +5205,6 @@ digit.smol: # arcadewise@hackclub.com
 in-synch.smol: # arcadewise@hackclub.com
   type: CNAME
   value: 437c8892af4826a1.vercel-dns-013.com.
-snake: # U07EB2Y76DP
-- type: CNAME
-  value: yousnakewesnake.netlify.app.
-  ttl: 600
 snowglobe: # lola@hackclub.com U078JCFHQ3D
 - octodns:
     cloudflare:
@@ -5402,9 +5281,6 @@ spotcheck:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.
-spp:
-  type: CNAME
-  value: spphacks.netlify.com.
 sprig: # jared@hackclub.com U07HEH4N8UV
   type: CNAME
   value: 763e4457b6bd8b0a.vercel-dns-016.com.
@@ -5521,9 +5397,6 @@ stasis-staging: # alexp@hackclub.com
 stastis: # alexp@hackclub.com
   type: CNAME
   value: b9385139e8ff984c.vercel-dns-016.com.
-statehigh:
-  type: CNAME
-  value: schacks.netlify.com.
 static: # rudy@hackclub.com
 - octodns:
     cloudflare:
@@ -5719,9 +5592,6 @@ tbp:
   - ns1.digitalocean.com.
   - ns2.digitalocean.com.
   - ns3.digitalocean.com.
-te:
-  type: CNAME
-  value: cname.vercel-dns.com.
 teach:
   type: CNAME
   value: hackclub.github.io.
@@ -5746,9 +5616,6 @@ telemetry:
 telescreen: # echo@hackclub.com U080A3QP42C
   type: CNAME
   value: ba32d3e933e777cb.vercel-dns-013.com.
-ten-days-of-code:
-  type: CNAME
-  value: cname.vercel-dns.com.
 terminalcraft:
 - type: CNAME
   value: 21a914e9b89646d3.vercel-dns-016.com.
@@ -5981,9 +5848,6 @@ ucat: # echo@hackclub.com U080A3QP42C & U0A5PLKMB25
 uet:
 - type: CNAME
   value: 5637f2843e643c1a.vercel-dns-016.com.
-uk:
-  type: CNAME
-  value: a05569dabb46ea5b.vercel-dns-016.com.
 undercity:
 - type: CNAME
   value: 79f8138b4bd40c5d.vercel-dns-016.com.
@@ -6014,12 +5878,6 @@ urspace: # selena@hackclub.com
       proxied: true
   type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
-uwu: # U08PD2ZB3DL
-- type: CNAME
-  value: cname.vercel-dns.com.
-v2:
-- type: CNAME
-  value: cname.vercel-dns.com.
 submit.v2:
 - octodns:
     cloudflare:
@@ -6122,9 +5980,6 @@ schedule.webdev: # lynn@hackclub.com U07ULNFPQ4T
 webring: # mahad@hackclub.com U059VC0UDEU
   type: CNAME
   value: c2344de079d02c17.vercel-dns-016.com.
-webstergroves:
-- type: CNAME
-  value: shootmessaging.netlify.app.
 webventure:
 - type: CNAME
   value: ansh3108.github.io.
@@ -6222,12 +6077,6 @@ ysws-true-spend: # zach@hackclub.com
       proxied: true
   type: CNAME
   value: a.ingress.tier2.infra.hackclub.com.
-zachday:
-- type: CNAME
-  value: zachday.netlify.com.
-zachday23:
-- type: A
-  value: 150.136.142.44
 zephyr:
 - type: CNAME
   value: a8184c0f9860ff11.vercel-dns-016.com.


### PR DESCRIPTION
## Description of changes

Remove unused CNAME records and domain verification entries from the configuration file.

## Website content/purpose

<!-- No new subdomains are being added. -->

## HQ Sponsor

<!-- No new subdomains are being added. -->

