### PR TITLE
Delete record for dear-joe.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1727,9 +1727,6 @@ daysofservice:
 de: # echo@hackclub.com
 - type: CNAME
   value: 6cdac7be6b2e933b.vercel-dns-016.com.
-dear-joe:
-- type: CNAME
-  value: f888ad30fdf5a183.vercel-dns-016.com.
 defector: # lewin@hackclub.com
 - type: A
   value: 51.148.150.203


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME f888ad30fdf5a183.vercel-dns-016.com.` under `dear-joe.hackclub.com`.

Please review carefully before merging.
