### PR TITLE
Delete record for op.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4058,9 +4058,6 @@ onekey: # maxtran@hackclub.com U07F6FMJ97U
     cloudflare:
       proxied: true
   value: a.ingress.tier2.infra.hackclub.com.
-op:
-- type: CNAME
-  value: opstem.github.io.
 opensauce: # zach@hackclub.com
 - octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME opstem.github.io.` under `op.hackclub.com`.

Please review carefully before merging.
