### PR TITLE
Delete record for vmc.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5919,9 +5919,6 @@ visioneer:
 vote.visioneer:
 - type: CNAME
   value: cname.vercel-dns.com.
-vmc:
-- type: A
-  value: 45.61.162.143
 vote: # manitej@hackclub.com
 - octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `A 45.61.162.143` under `vmc.hackclub.com`.

Please review carefully before merging.
