### PR TITLE
Delete record for mcneil.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3646,9 +3646,6 @@ _gh-hackclubmchs-o.mchs:
 _github-pages-challenge-hackclubmchs.mchs:
 - type: TXT
   value: 7758abbb60ddb92f7bca19e65bca60
-mcneil:
-- type: A
-  value: 70.123.47.120
 mea:
 - type: CNAME
   value: meahackclub.netlify.app.


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `A 70.123.47.120` under `mcneil.hackclub.com`.

Please review carefully before merging.
