### PR TITLE
Delete record for coins.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1436,9 +1436,6 @@ codex: # alexren@hackclub.com
 coeur: # olive@hackclub.com @Olive @Ghost of L87 (Lynn)
   - type: CNAME
     value: 24bb8e539241bbef.vercel-dns-016.com.
-coins:
-  - type: A
-    value: 173.208.140.124
 comms:
   - octodns:
       cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `A 173.208.140.124` under `coins.hackclub.com`.

Please review carefully before merging.
