### PR TITLE
Delete record for market.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3578,12 +3578,6 @@ manor:
 markdown:
   type: CNAME
   value: c02a5eb37aa5d3c3.vercel-dns-016.com.
-market:
-  - octodns:
-      cloudflare:
-        proxied: true
-    type: CNAME
-    value: a.selfhosted.hackclub.com.
 maxday:
   type: CNAME
   value: maxday-prod.netlify.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @sophiayduan via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME a.selfhosted.hackclub.com.` under `market.hackclub.com`.

Please review carefully before merging.
