### PR TITLE
Update record for ops.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4039,11 +4039,11 @@ opensauce-leaderboard: # zach@hackclub.com
     type: CNAME
     value: a.limited.selfhosted.hackclub.com.
 ops: # leo@hackclub.com U07BLJ1MBEE
-  - octodns:
-      cloudflare:
-        proxied: false
-    type: CNAME
-    value: a.ingress.tier2.infra.hackclub.com.
+- octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 orchard: #tongyu@hackclub.com U07DJMFAQQP
   - octodns:
       cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME a.ingress.tier2.infra.hackclub.com.` under `ops.hackclub.com`.

### Updated record
```yaml
ops: # leo@hackclub.com U07BLJ1MBEE
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `leo@hackclub.com U07BLJ1MBEE`

Please review carefully before merging.
