### PR TITLE
Delete record for duos.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1850,12 +1850,6 @@ dummies:
       proxied: true
   type: CNAME
   value: a.selfhosted.hackclub.com.editor
-duos: # brendan@hackclub.com
-- octodns:
-    cloudflare:
-      proxied: true
-  type: CNAME
-  value: a.ingress.tier2.infra.hackclub.com.
 easel:
   type: CNAME
   value: 46c19d5618208b3e.vercel-dns-016.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @breynard0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME a.ingress.tier2.infra.hackclub.com.` under `duos.hackclub.com`.

Please review carefully before merging.
