### PR TITLE
Add record for whoami.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -5965,6 +5965,12 @@ whimsy: # katiesue@hackclub.com
   - type: CNAME
     value: ad97879918161518.vercel-dns-017.com.
     ttl: 600
+whoami: # cloudglides@proton.me U0A2EKA9FAL
+- octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 whs:
   - type: CNAME
     value: whs-hackclub.netlify.com.


### PR DESCRIPTION
## DNS Editor submission

Opened by @cloudglides via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
whoami: # cloudglides@proton.me U0A2EKA9FAL
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `cloudglides@proton.me U0A2EKA9FAL`

Please review carefully before merging.
