### PR TITLE
Add record for bulky.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1078,6 +1078,12 @@ builders-club: # soonk@hacklub.com
 bulc:
   - type: CNAME
     value: 5637f2843e643c1a.vercel-dns-016.com.
+bulky: # selena@hackclub.com U06U1CBK589
+- octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 bunbougu:
   - type: CNAME
     value: applepieeeeee.github.io.


### PR DESCRIPTION
## DNS Editor submission

Opened by @possiblyselena via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
bulky: # selena@hackclub.com U06U1CBK589
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `selena@hackclub.com U06U1CBK589`

Please review carefully before merging.
