### PR TITLE
Adding *.infra.cq.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -1577,6 +1577,12 @@ cq: # ruben@scstudios.tech U0AHNB20WDD
         proxied: true
     type: CNAME
     value: a.ingress.tier2.infra.hackclub.com.
+'*.infra.cq': # ruben@scstudios.tech U0AHNB20WDD, for reviewer vms
+  - octodns:
+      cloudflare:
+        proxied: true
+    type: CNAME
+    value: 8b7247cd-3175-4695-acd3-30a116fe01ad.cfargotunnel.com.
 craft:
   - type: CNAME
     value: craft-ept.pages.dev.


### PR DESCRIPTION
# Adding `*.infra.cq.hackclub.com`

## Description of changes
Add a wildcard CNAME for `*.infra.cq.hackclub.com`, routed through the Cloudflare Tunnel used by CQ’s isolated review infrastructure. This goes to my proxmox server which will provision vms, and this url will provide hostnames for reviewer VMs.


## Website content/purpose
This wildcard domain is for the reviewer vm infrastructure, mainly remote shell access.

## HQ Sponsor
<!-- If you are requesting a subdomain under `hackclub.com`, please state the name of your hq POC/sponsor: -->
Arcade W is sponsoring this program.