### PR TITLE
Add record for platformer.dino.icu

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -970,6 +970,9 @@ piyush:
   ttl: 600
   type: CNAME
   value: dino.piyush.ovh.
+platformer: # abtheinnovator@gmail.com
+- type: A
+  value: 216.198.79.1
 playground: #https://github.com/thagreatjoel/Playground
   ttl: 600
   type: CNAME


### PR DESCRIPTION
## DNS Editor submission

Opened by @abinnovator via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
platformer: # abtheinnovator@gmail.com
- type: A
  value: 216.198.79.1
```

Contact: `abtheinnovator@gmail.com`

Please review carefully before merging.
