### PR TITLE
Add local DNS validation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ SUBDOMAIN_NAME: # email@example.com U012AB345CD
 
 That's it! Someone with contributor access to the repo will then review your PR.
 
+Before opening the PR, you can run the same local checks used by the repository:
+
+```sh
+pip install natsort ruamel.yaml
+./bin/check
+```
+
+This parses every zone file and checks that records are in the expected order.
+
 If you're asked to make any changes to your pull request, please amend it by committing to your fork, instead of closing it and creating another.
 
 ### Replacing a `CNAME` record with another record type

--- a/bin/check
+++ b/bin/check
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+export ROOT_DIR
+
+cd "$ROOT_DIR"
+
+python3 - <<'PY'
+import os
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+root = Path(os.environ['ROOT_DIR'])
+yaml = YAML()
+zone_files = sorted(root.glob('*.yaml'))
+errors = []
+
+for path in zone_files:
+    try:
+        with path.open() as stream:
+            yaml.load(stream)
+    except Exception as error:
+        errors.append(f'{path.name}: {error}')
+
+if errors:
+    print('Invalid YAML found:')
+    print('\n'.join(f'  - {error}' for error in errors))
+    raise SystemExit(1)
+
+print(f'Parsed {len(zone_files)} zone files successfully.')
+PY
+
+python3 bin/sort-zones --check


### PR DESCRIPTION
## What changed

This PR adds a small local validation command for DNS contributors and documents how to run it before opening a pull request.

### Added

- Added an executable `bin/check` script.
- The script parses all top-level DNS zone files using `ruamel.yaml`.
- Invalid YAML files are reported with their filename and parsing error.
- The script also runs the existing `bin/sort-zones --check` command to verify DNS record ordering.
- Added README instructions explaining how to install the required dependencies and run the local checks.

## Why

The repository already validates YAML syntax and record ordering through CI, but contributors did not have one documented command to run these checks locally.

This change makes the contribution workflow easier to discover and helps contributors catch common validation errors before opening a PR.

## Validation

The following checks pass successfully:

```sh
./bin/check
python3 bin/sort-zones --check
git diff --check

