### PR TITLE
Update record for www.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -6049,7 +6049,10 @@ wristband: # anson@hackclub.com
 wshackclub:
   - type: A
     value: 35.158.87.123
-www:
+www: # echo@hackclub.com
+- octodns:
+    cloudflare:
+      proxied: true
   type: CNAME
   value: fdd973c84b10aa8e.vercel-dns-016.com.
 you-ship-we-clip:


### PR DESCRIPTION
## DNS Editor submission

Opened by @3kh0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME fdd973c84b10aa8e.vercel-dns-016.com.` under `www.hackclub.com`.

### Updated record
```yaml
www: # echo@hackclub.com
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: fdd973c84b10aa8e.vercel-dns-016.com.
```

Contact: `echo@hackclub.com`

Please review carefully before merging.
