### PR TITLE
Add record for halflife.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2700,6 +2700,9 @@ hackyholidays:
 haj4ever: # U07UK4S94KC
   - type: CNAME
     value: cname.vercel-dns.com.
+halflife: # arcadewise@hackclub.com
+- type: CNAME
+  value: ef2e4b73c62eef4a.vercel-dns-013.com.
 hall-of-fame: # mattsoh@hackclub.com U07DPHQCCCS
   - octodns:
       cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @l3gacyb3ta via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
halflife: # arcadewise@hackclub.com
- type: CNAME
  value: ef2e4b73c62eef4a.vercel-dns-013.com.
```

Contact: `arcadewise@hackclub.com`

Please review carefully before merging.
