### PR TITLE
Delete record for apt.lookout.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3501,9 +3501,6 @@ lookout: # samliu@hackclub.com
         proxied: true
     type: CNAME
     value: b.selfhosted.hackclub.com.
-apt.lookout: # anson@hackclub.com
-  - type: CNAME
-    value: hackclub.github.io.
 pkg.lookout: # anson@hackclub.com
   - type: CNAME
     value: hackclub.github.io.


### PR DESCRIPTION
## DNS Editor submission

Opened by @anscg via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Delete
Removing `CNAME hackclub.github.io.` under `apt.lookout.hackclub.com`.

Please review carefully before merging.
