### PR TITLE
Add record for fillout-hca-redirect.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -2145,6 +2145,12 @@ feud: # emme@hackclub.com U0BELFW91AN
 fhs:
   - type: CNAME
     value: cname.vercel-dns.com.
+fillout-hca-redirect: # brendan@hackclub.com
+- octodns:
+    cloudflare:
+      proxied: true
+  type: CNAME
+  value: a.ingress.tier2.infra.hackclub.com.
 fillout-ysws-nps: # zach@hackclub.com
   octodns:
     cloudflare:


### PR DESCRIPTION
## DNS Editor submission

Opened by @breynard0 via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### New record
```yaml
fillout-hca-redirect: # brendan@hackclub.com
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: a.ingress.tier2.infra.hackclub.com.
```

Contact: `brendan@hackclub.com`

Please review carefully before merging.
