### PR TITLE
Deleting `whoami.hackclub.com`

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -6001,12 +6001,6 @@ whimsy: # katiesue@hackclub.com
   - type: CNAME
     value: ad97879918161518.vercel-dns-017.com.
     ttl: 600
-whoami: # cloudglides@proton.me U0A2EKA9FAL
-- octodns:
-    cloudflare:
-      proxied: true
-  type: CNAME
-  value: a.ingress.tier2.infra.hackclub.com.
 whs:
   - type: CNAME
     value: whs-hackclub.netlify.com.


### PR DESCRIPTION
# [Deleting] `whoami.hackclub.com`

## Description of changes
Removes the `whoami` CNAME entry from `hackclub.com.yaml` (was pointing to `a.ingress.tier2.infra.hackclub.com`).

## Website content/purpose
N/A — deletion.

## HQ Sponsor
N/A — deletion (entry was owned by cloudglides@proton.me / U0A2EKA9FAL).