### PR TITLE
Update record for wiiuavi1.dino.icu

### DIFF
--- a/dino.icu.yaml
+++ b/dino.icu.yaml
@@ -1372,8 +1372,8 @@ whoami: # cloudglides@proton.me U0A2EKA9FAL
   type: A
   value: 216.198.79.1
 wiiuavi1: # @wiiuavi on slack, U08SB23AY7P
-- type: AAAA
-  value: 2a01:4f9:3a:276e::1802
+- type: CNAME
+  value: wiiuavi.hackclub.app.
 wikibase: # wikibase for the Hack Club community, to be managed by @recaptime-dev team through @ajhalili2006
   ttl: 600
   type: CNAME


### PR DESCRIPTION
## DNS Editor submission

Opened by @wiiuavi via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `AAAA 2a01:4f9:3a:276e::1802` under `wiiuavi1.dino.icu`.

### Updated record
```yaml
wiiuavi1: # @wiiuavi on slack, U08SB23AY7P
- type: CNAME
  value: wiiuavi.hackclub.app.
```

Contact: `@wiiuavi on slack, U08SB23AY7P`

Please review carefully before merging.
