### PR TITLE
Update record for keyframe.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3401,8 +3401,11 @@ _github-pages-challenge-kerala-hackclub.kerala:
   - type: TXT
     value: f39cf4bf21f2e8087c97294b2944e4
 keyframe: # nick@hackclub.com U06FMCCDS1K
+- octodns:
+    cloudflare:
+      proxied: true
   type: CNAME
-  value: keyframe.hackclub.dev.
+  value: c0a99f5585a1b6c5.vercel-dns-013.com.
 kiit:
   type: CNAME
   value: alpha-9h3.pages.dev.


### PR DESCRIPTION
## DNS Editor submission

Opened by @autowattage via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME keyframe.hackclub.dev.` under `keyframe.hackclub.com`.

### Updated record
```yaml
keyframe: # nick@hackclub.com U06FMCCDS1K
- octodns:
    cloudflare:
      proxied: true
  type: CNAME
  value: c0a99f5585a1b6c5.vercel-dns-013.com.
```

Contact: `nick@hackclub.com U06FMCCDS1K`

Please review carefully before merging.
