### PR TITLE
Update record for keyframe.hackclub.com

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -3401,10 +3401,7 @@ _github-pages-challenge-kerala-hackclub.kerala:
   - type: TXT
     value: f39cf4bf21f2e8087c97294b2944e4
 keyframe: # nick@hackclub.com U06FMCCDS1K
-- octodns:
-    cloudflare:
-      proxied: true
-  type: CNAME
+- type: CNAME
   value: c0a99f5585a1b6c5.vercel-dns-013.com.
 kiit:
   type: CNAME


### PR DESCRIPTION
## DNS Editor submission

Opened by @autowattage via [hack-club-dns-editor[bot]](https://github.com/apps/hack-club-dns-editor).

### Edit
Replacing existing `CNAME c0a99f5585a1b6c5.vercel-dns-013.com.` under `keyframe.hackclub.com`.

### Updated record
```yaml
keyframe: # nick@hackclub.com U06FMCCDS1K
- type: CNAME
  value: c0a99f5585a1b6c5.vercel-dns-013.com.
```

Contact: `nick@hackclub.com U06FMCCDS1K`

Please review carefully before merging.
